### PR TITLE
Allow building a client without resource management

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ The session cache file uses the TOML format. The default file name is `.pyodk_ca
 ```python
 from pyodk.client import Client
 
-with Client() as client:
-    projects = client.projects.list()
-    forms = client.forms.list()
-    submissions = client.submissions.list(form_id=next(forms).xmlFormId)
-    form_data = client.submissions.get_table(form_id="birds", project_id=8)
+client = Client()
+projects = client.projects.list()
+forms = client.forms.list()
+submissions = client.submissions.list(form_id=next(forms).xmlFormId)
+form_data = client.submissions.get_table(form_id="birds", project_id=8)
 ```
 
 The `Client` is not specific to a project, but a default `project_id` can be set by:
@@ -85,6 +85,12 @@ The `Client` is specific to a configuration and cache file. These approximately 
 - Setting environment variables `PYODK_CONFIG_FILE` and `PYODK_CACHE_FILE`
 - Init arguments: `Client(config_path="my_config.toml", cache_path="my_cache.toml")`.
 
+**NOTE:** Creating a `Client` opens a session. If you use `pyodk` as part of a long-running program, you should clean up that session. You can explicitly call `client.close` when you are done making requests or use a `with` statement to automatically clean up resources:
+```
+with Client() as client:
+  projects = client.projects.list()
+  ...
+```
 
 ## Endpoints
 

--- a/pyodk/client.py
+++ b/pyodk/client.py
@@ -57,6 +57,9 @@ class Client:
             session=self.session, default_project_id=self.project_id
         )
 
+        self.session.__enter__()
+        self._login()
+
     @property
     def project_id(self) -> Optional[int]:
         if self._project_id is None:
@@ -75,16 +78,11 @@ class Client:
         )
         self.session.headers["Authorization"] = "Bearer " + token
 
-    def open(self) -> "Client":
-        self.session.__enter__()
-        self._login()
-        return self
-
     def close(self, *args):
         self.session.__exit__(*args)
 
     def __enter__(self) -> "Client":
-        return self.open()
+        return self
 
     def __exit__(self, *args):
         return self.close(*args)


### PR DESCRIPTION
I expect most users of this library will:
- write small scripts that run quickly
- write snippets in a Jupyter notebook
- explore from the Python repl

Having to use a `with` block to build a client is a barrier to all those usages. As far as I know there's no reason to close a session for any of those. The same way that session itself i[s primarily documented as being used without ever being closed](https://requests.readthedocs.io/en/latest/user/advanced/), I think we should document building a client directly and only briefly document that resource management can be done.

I'm opening this mostly to show what I'd like the docs to look like and to have a conversation around it (@lindsay-stevens @samwel2000). This relates to our users' primary interaction with the library so I think it's important.

I realize `client = Client().open()` is currently possible but that seems unexpected to me as well.

Some tests fail so there are changes needed to the implementation!