### PR TITLE
Remove Binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # pyODK
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/getodk/pyodk/HEAD?labpath=examples)
 
 An API client for ODK Central that makes it easier to interact with data in ODK from Python.
 


### PR DESCRIPTION
I thought the Binder link was going to be a cool way to get started but really it takes too many steps to get going:
- As far as I can tell it's not possible to create a dot file in the home directory so you have to pass in the path to your config
- You'd have to get your server in the same config as mine to get much out of the examples
- The static previews from Github are probably just as useful

For now if someone knows how to use Binder and find it useful they can set up the link themselves.