### PR TITLE
Release triggers multiple runs, so use published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: [release]
+on:
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
Release seems to trigger three action runs:
- Created: https://github.com/getodk/pyodk/actions/runs/3131303079
- Released: https://github.com/getodk/pyodk/actions/runs/3131303075
- Published: https://github.com/getodk/pyodk/actions/runs/3131303071

This PR only runs when the release is published.

More at https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release