### PR TITLE
Fix import in notebook example

### DIFF
--- a/examples/2022-10-pyodk-webinar.ipynb
+++ b/examples/2022-10-pyodk-webinar.ipynb
@@ -71,7 +71,7 @@
     }
    ],
    "source": [
-    "from pyodk.Client import Client\n",
+    "from pyodk.client import Client\n",
     "\n",
     "client = Client()\n",
     "client.open()\n",


### PR DESCRIPTION
Thank you, @Thaliehln!

This specific one is a typo I've made more than once. For better or for worse, both do work so it's likely we'll see both pop up. I think it would be ideal for only `pyodk.client` to work so examples are consistent but I'm not sure how to achieve that.

EDIT: now I see from @Thaliehln's note that it did /not/ work. What platform are you on, @Thaliehln? I'm wondering whether the behavior I get is related to how macOS treats case for filenames. Regardless, we should be consistent in examples.