### PR TITLE
Allow building a client without resource management

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,27 @@ The session cache file uses the TOML format. The default file name is `.pyodk_ca
 
 # Usage
 
+Authentication is triggered by the first API call on the Client, or by using `Client.open()`. Use `Client.close()` to clean up a client session. Clean up is recommended for long-running scripts, e.g. analysis notebooks, web apps, etc.
+
 ## Examples
 
 ```python
 from pyodk.client import Client
 
+client = Client()
+projects = client.projects.list()
+forms = client.forms.list()
+submissions = client.submissions.list(form_id=next(forms).xmlFormId)
+form_data = client.submissions.get_table(form_id="birds", project_id=8)
+comments = client.submissions.list_comments(form_id=next(forms).xmlFormId, instance_id="uuid:...")
+client.close()
+```
+
+When using the Client as a context manager, authentication occurs at entry and clean up occurs at exit.
+
+```python
 with Client() as client:
-    projects = client.projects.list()
-    forms = client.forms.list()
-    submissions = client.submissions.list(form_id=next(forms).xmlFormId)
-    form_data = client.submissions.get_table(form_id="birds", project_id=8)
-    comments = client.submissions.list_comments(form_id=next(forms).xmlFormId, instance_id="uuid:...")
+    print(client.projects.list())
 ```
 
 **👉 Looking for more advanced examples? You can find detailed Jupyter notebooks, scripts, and webinars [here](examples).**

--- a/pyodk/_endpoints/auth.py
+++ b/pyodk/_endpoints/auth.py
@@ -1,16 +1,18 @@
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pyodk._utils import config
-from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
+
+if TYPE_CHECKING:
+    from pyodk._utils.session import Session
 
 log = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, session: Session, cache_path: Optional[str] = None) -> None:
-        self.session: Session = session
+    def __init__(self, session: "Session", cache_path: Optional[str] = None) -> None:
+        self.session: "Session" = session
         self.cache_path: str = cache_path
 
     def verify_token(self, token: str) -> str:

--- a/tests/endpoints/test_comments.py
+++ b/tests/endpoints/test_comments.py
@@ -7,7 +7,7 @@ from pyodk.client import Client
 from tests.resources import CONFIG_DATA, comments_data
 
 
-@patch("pyodk.client.Client._login", MagicMock())
+@patch("pyodk._utils.session.Auth.login", MagicMock())
 @patch("pyodk._utils.config.read_config", MagicMock(return_value=CONFIG_DATA))
 class TestComments(TestCase):
     def test_list__ok(self):

--- a/tests/endpoints/test_forms.py
+++ b/tests/endpoints/test_forms.py
@@ -7,7 +7,7 @@ from pyodk.client import Client
 from tests.resources import CONFIG_DATA, forms_data
 
 
-@patch("pyodk.client.Client._login", MagicMock())
+@patch("pyodk._utils.session.Auth.login", MagicMock())
 @patch("pyodk._utils.config.read_config", MagicMock(return_value=CONFIG_DATA))
 class TestForms(TestCase):
     def test_list__ok(self):

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -8,7 +8,7 @@ from pyodk.client import Client
 from tests.resources import CONFIG_DATA, projects_data
 
 
-@patch("pyodk.client.Client._login", MagicMock())
+@patch("pyodk._utils.session.Auth.login", MagicMock())
 @patch("pyodk._utils.config.read_config", MagicMock(return_value=CONFIG_DATA))
 class TestProjects(TestCase):
     def test_list__ok(self):

--- a/tests/endpoints/test_submissions.py
+++ b/tests/endpoints/test_submissions.py
@@ -7,7 +7,7 @@ from pyodk.client import Client
 from tests.resources import CONFIG_DATA, submissions_data
 
 
-@patch("pyodk.client.Client._login", MagicMock())
+@patch("pyodk._utils.session.Auth.login", MagicMock())
 @patch("pyodk._utils.config.read_config", MagicMock(return_value=CONFIG_DATA))
 class TestSubmissions(TestCase):
     def test_list__ok(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,18 +8,24 @@ class TestUsage(TestCase):
     """Tests for experimenting with usage scenarios / general debugging."""
 
     def test_direct(self):
+        client = Client()
+        projects = client.projects.list()
+        forms = client.forms.list()
+        submissions = client.submissions.list(form_id=forms[3].xmlFormId)
+        form_data = client.submissions.get_table(form_id=forms[3].xmlFormId)
+        form_data_params = client.submissions.get_table(
+            form_id="range",
+            table_name="Submissions",
+            count=True,
+        )
+        comments = client.submissions.list_comments(
+            form_id="range",
+            instance_id="uuid:2c296eae-2708-4a89-bfe7-0f2d440b7fe8",
+        )
+        print([projects, forms, submissions, form_data, form_data_params, comments])
+
+    def test_direct_context(self):
         with Client() as client:
             projects = client.projects.list()
             forms = client.forms.list()
-            submissions = client.submissions.list(form_id=forms[3].xmlFormId)
-            form_data = client.submissions.get_table(form_id=forms[3].xmlFormId)
-            form_data_params = client.submissions.get_table(
-                form_id="range",
-                table_name="Submissions",
-                count=True,
-            )
-            comments = client.submissions.list_comments(
-                form_id="range",
-                instance_id="uuid:2c296eae-2708-4a89-bfe7-0f2d440b7fe8",
-            )
-            print([projects, forms, submissions, form_data, form_data_params, comments])
+        print(projects, forms)


### PR DESCRIPTION
Closes #21

Branched from `pyodk-6` assuming that #25 is more or less good to go.

#### What has been done to verify that this works as intended?
Existing tests pass.

#### Why is this the best possible solution? Were any other approaches considered?
This makes login transparent to the user without needing a context manager, and avoids putting auth inside `client.__init__` which I think is a bit messy generally and for error handling.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No changes except where users want to adopt this new default usage style. The context manager style still works, as does `client.open()`.

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes, the README is updated with the new usage example, as well as some details on login / clean up.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `python bin/pre_commit.py` to format / lint code
- [x] verified that any code or assets from external sources are properly credited in comments
