### PR TITLE
Fix linter check for black and isort not failing when changes required

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,7 +31,10 @@ jobs:
           pip list
 
       # Linters.
-      - run: python bin/pre_commit.py
+      - run: black pyodk tests bin --check --diff
+      - run: isort pyodk tests bin --check-only --diff
+      - run: flake8 pyodk tests bin
+      - run: pycodestyle pyodk tests bin
 
   test:
     runs-on: ${{ matrix.os }}

--- a/pyodk/endpoints/forms.py
+++ b/pyodk/endpoints/forms.py
@@ -34,6 +34,7 @@ class URLs(bases.Model):
     list: str = "projects/{project_id}/forms"
     get: str = "projects/{project_id}/forms/{form_id}"
 
+
 class FormService(bases.Service):
     __slots__ = ("urls", "session", "default_project_id", "default_form_id")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,12 +18,4 @@ class TestUsage(TestCase):
                 table_name="Submissions",
                 count=True,
             )
-            print(
-                [
-                    projects,
-                    forms,
-                    submissions,
-                    form_data,
-                    form_data_params
-                ]
-            )
+            print([projects, forms, submissions, form_data, form_data_params])


### PR DESCRIPTION
Linters `black` and `isort` returncode is 0 when fixes required and applied, so add arguments that make it returncode 1 when fixes required. Linters `flake8 and `pycodestyle` return 1 already.

#### What has been done to verify that this works as intended?

Same as https://github.com/XLSForm/pyxform/pull/631

#### Why is this the best possible solution? Were any other approaches considered?

It's the required arguments

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

None, only relevant for GitHub actions

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

None

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `python bin/pre_commit.py` to format / lint code
- [x] verified that any code or assets from external sources are properly credited in comments
