### PR TITLE
Remove duplicate `https://` from `server_url` in app_user_provisioner.py

### DIFF
--- a/examples/app_user_provisioner.py
+++ b/examples/app_user_provisioner.py
@@ -65,7 +65,7 @@ for user in to_provision:
             print(err)
 
     # Customize the QR code
-    url = f"https://{client.auth.session.base_url}key/{provision_resp.json()['token']}/projects/{PROJECT}"
+    url = f"{client.auth.session.base_url}key/{provision_resp.json()['token']}/projects/{PROJECT}"
     COLLECT_SETTINGS["general"]["server_url"] = url
     COLLECT_SETTINGS["project"]["name"] = f"{PROJECT_NAME}: {user}"
     COLLECT_SETTINGS["general"]["username"] = user


### PR DESCRIPTION
When testing `app_user_provisioner.py`, I noticed updates were failing after scanning the QR code. This appears to because `https://` is being duplicated in `server_url`:

```
'server_url': 'https://https://...',
```

It looks like pyodk also includes `https://` in `client.auth.session.base_url`, so it can be removed from `app_user_provisioner.py`:

```
>>> from pyodk.client import Client
>>> client = Client().open()
>>> client.auth.session.base_url
'https://<snip>/v1/'
```

```
$ pip freeze | grep pyodk
pyodk==0.1.0
```