### PR TITLE
dev: update github workflow deps to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
         python: ['3.8']
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
       # Install dependencies.
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Python cache with dependencies.
         id: python-cache
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,14 +10,14 @@ jobs:
         python: ['3.8']
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
       # Install dependencies.
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Python cache with dependencies.
         id: python-cache
         with:
@@ -48,14 +48,14 @@ jobs:
           - os: windows-latest
             windows_nose_args: --traverse-namespace ./tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
       # Install dependencies.
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Python cache with dependencies.
         id: python-cache
         with:
@@ -87,7 +87,7 @@ jobs:
           twine check dist/*
       - name: Upload sdist and wheel.
         if: success()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pyodk--on-${{ matrix.os }}--py${{ matrix.python }}
           path: ${{ github.workspace }}/dist/pyodk*


### PR DESCRIPTION
The v2 dependencies are now showing a deprecation warning, [as shown here](https://github.com/lindsay-stevens/pyodk/actions/runs/4339963389).

#### What has been done to verify that this works as intended?

Successful workflow run [here](https://github.com/lindsay-stevens/pyodk/actions/runs/4341141464).

#### Why is this the best possible solution? Were any other approaches considered?

N/A

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Does not affect users.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `python bin/pre_commit.py` to format / lint code
- [x] verified that any code or assets from external sources are properly credited in comments
