### PR TITLE
Add forms.update parameter to set version

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,6 +57,15 @@ class TestUsage(TestCase):
                 attachments=[(RESOURCES / "forms" / "fruits.csv").as_posix()],
             )
 
+    def test_form_update__attachments__with_version_updater(self):
+        """Should create a new version with new attachment and updated version."""
+        with Client() as client:
+            client.forms.update(
+                form_id="pull_data",
+                attachments=[(RESOURCES / "forms" / "fruits.csv").as_posix()],
+                version_updater=lambda v: v + "_1",
+            )
+
     def test_project_create_app_users__names_only(self):
         """Should create project app users."""
         client = Client()


### PR DESCRIPTION
Closes #34

#### What has been done to verify that this works as intended?

Added unit / mocked / integration tests.

#### Why is this the best possible solution? Were any other approaches considered?

As specified in #34, except that the version passed to the version_updater func is the current form version, not the incoming draft version. In the previous issue / PR discussion (and the quoted request) it seems like it should be the current, so that the function can iterate it somehow for the new form version.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Adds a feature. Also tried to tidy up the docstring to make it clearer what is accepted by the method and how it behaves.

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

Updated docstring should be pulled into mkdocs when that's ready.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `python bin/pre_commit.py` to format / lint code
- [x] verified that any code or assets from external sources are properly credited in comments
