### PR TITLE
Force the push to the docs branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
 
       # Publish docs.
       - name: Publish docs to gh-pages
-        run: mkdocs gh-deploy
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
Build failure at https://github.com/getodk/pyodk/actions/runs/4615333206/jobs/8159111521.

```
To https://github.com/getodk/pyodk
 ! [rejected]        gh-pages -> gh-pages (fetch first)
error: failed to push some refs to 'https://github.com/getodk/pyodk'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

Found solution at https://squidfunk.github.io/mkdocs-material/publishing-your-site