### PR TITLE
fix: docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 An API client for the [ODK Central API](https://odkcentral.docs.apiary.io). Use it to interact with your data and automate common tasks from Python.
 
-This library aims to make common data analysis and workflow automation tasks as simple as possible by providing clear method names, types, and examples. It also provides convenient access to the full API using [HTTP verb methods](#raw-http-requests).
+This library aims to make common data analysis and workflow automation tasks as simple as possible by providing clear method names, types, and examples. It also provides convenient access to the full API using [HTTP verb methods](https://getodk.github.io/pyodk/http-methods/).
 
 ## Install
 

--- a/docs/http-methods.md
+++ b/docs/http-methods.md
@@ -9,4 +9,4 @@ client.post("projects/7/app-users", json={"displayName": "Lab Tech"})
 
 These methods provide convenient access to `Client.session`, which is a [`requests.Session`](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects) object subclass. The `Session` has customised to prefix request URLs with the `base_url` from the pyodk config. For example with a base_url `https://www.example.com`, a call to `client.session.get("projects/8")` gets the details of `project_id=8`, using the full url `https://www.example.com/v1/projects/8`.
 
-Learn more in [this example](/examples/beyond-library-methods/).
+Learn more in [this example](https://getodk.github.io/pyodk/examples/beyond-library-methods/).


### PR DESCRIPTION
Closes #51

#### What has been done to verify that this works as intended?

Looked at docs site to see what link should be and updated the files accordingly.

#### Why is this the best possible solution? Were any other approaches considered?

Correct links

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Better docs navigation

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

Docs update

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `python bin/pre_commit.py` to format / lint code
- [x] verified that any code or assets from external sources are properly credited in comments
