### PR TITLE
Fix API docs links and internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pyODK
 [![pypi](https://img.shields.io/pypi/v/pyodk.svg)](https://pypi.python.org/pypi/pyodk)
 
-An API client for the [ODK Central API](https://odkcentral.docs.apiary.io). Use it to interact with your data and automate common tasks from Python.
+An API client for the [ODK Central API](https://docs.getodk.org/central-api). Use it to interact with your data and automate common tasks from Python.
 
 This library aims to make common data analysis and workflow automation tasks as simple as possible by providing clear method names, types, and examples. It also provides convenient access to the full API using [HTTP verb methods](https://getodk.github.io/pyodk/http-methods/).
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -10,7 +10,7 @@ A standalone Jupyter notebook intended to introduce `pyodk` and show how it can 
 
 ## [Going beyond `pyodk`'s library methods](beyond-library-methods.ipynb)
 
-A standalone Jupyter notebook that shows how the raw HTTP method access and the [API docs](https://odkcentral.docs.apiary.io/) can be used together to make use of the full ODK Central API.
+A standalone Jupyter notebook that shows how the raw HTTP method access and the [API docs](https://docs.getodk.org/central-api) can be used together to make use of the full ODK Central API.
 
 ## [Working with repeats](working-with-repeats.ipynb)
 

--- a/docs/http-methods.md
+++ b/docs/http-methods.md
@@ -1,6 +1,6 @@
 # HTTP verb methods
 
-For interacting with parts of the ODK Central API ([docs](https://odkcentral.docs.apiary.io)) that have not been implemented in `pyodk`, use HTTP verb methods exposed on the `Client`:
+For interacting with parts of the ODK Central API ([docs](https://docs.getodk.org/central-api)) that have not been implemented in `pyodk`, use HTTP verb methods exposed on the `Client`:
 
 ```python
 client.get("projects/8")

--- a/pyodk/_endpoints/auth.py
+++ b/pyodk/_endpoints/auth.py
@@ -44,7 +44,7 @@ class AuthService:
         """
         Get a new token from Central by creating a new session.
 
-        https://odkcentral.docs.apiary.io/#reference/authentication/session-authentication/logging-in
+        https://docs.getodk.org/central-api-authentication/#logging-in
 
         :param username: The username of the Web User to auth with.
         :param password: The Web User's password.


### PR DESCRIPTION
One thing I noticed that we only publish docs on release, so after this is merged, I will need to run `mkdocs gh-deploy --force` locally...