### PR TITLE
62: add support for entities and entity_lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ For interactive testing, debugging, or sanity checking workflows, end-to-end tes
 1. Create a test project in Central.
 2. Create a test user in Central. It can be a site-wide Administrator. If it is not an Administrator, assign the user to the project with "Project Manager" privileges, so that forms and submissions in the test project can be uploaded and modified.
 3. Save the user's credentials and the project ID in a `.pyodk_config.toml` (or equivalent) as described in the above section titled "Configure".
-4. When the tests in `test_client.py` are run, the test setup method should automatically create a few forms and submissions for testing with. At a minimum these allow the tests to pass, but can also be used to interactively test or debug.
+4. When the tests in `test_client.py` are run, the test setup method should automatically create a few fixtures for testing with. At a minimum these allow the tests to pass, but can also be used to interactively test or debug.
 
 
 ## Release

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,0 +1,3 @@
+# Entities
+
+::: pyodk._endpoints.entities.EntityService

--- a/docs/entity_lists.md
+++ b/docs/entity_lists.md
@@ -1,0 +1,3 @@
+# Entity Lists
+
+::: pyodk._endpoints.entity_lists.EntityListService

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,9 +11,11 @@ watch:
 nav:
     - Overview: index.md
     - Client: client.md
+    - .entities: entities.md
+    - .entity_lists: entity_lists.md
     - .forms: forms.md
-    - .submissions: submissions.md
     - .projects: projects.md
+    - .submissions: submissions.md
     - HTTP methods: http-methods.md
     - Examples: examples/README.md
 

--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -131,7 +131,7 @@ class EntityService(bases.Service):
             method="POST",
             url=self.session.urlformat(self.urls.post, project_id=pid, el_name=eln),
             logger=log,
-            data=req_data,
+            json=req_data,
         )
         data = response.json()
         return Entity(**data)

--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -50,7 +50,9 @@ class EntityService(bases.Service):
     data = client.entities.list()
     ```
 
-    An EntityList is a list of Entities, e.g. `list[Entity]`.
+    Conceptually, an Entity's parent object is an EntityList. Each EntityList may
+    have multiple Entities. In Python parlance, EntityLists are like classes, while
+    Entities are like instances.
     """
 
     __slots__ = ("urls", "session", "default_project_id", "default_entity_list_name")

--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -1,0 +1,194 @@
+import logging
+from datetime import datetime
+from uuid import uuid4
+
+from pyodk._endpoints import bases
+from pyodk._utils import validators as pv
+from pyodk._utils.session import Session
+from pyodk.errors import PyODKError
+
+log = logging.getLogger(__name__)
+
+
+class CurrentVersion(bases.Model):
+    label: str
+    current: bool
+    creatorId: int
+    userAgent: str
+    version: int
+    baseVersion: int | None = None
+    conflictingProperties: list[str] | None = None
+
+
+class Entity(bases.Model):
+    uuid: str
+    creatorId: int
+    createdAt: datetime
+    currentVersion: CurrentVersion
+    updatedAt: datetime | None = None
+    deletedAt: datetime | None = None
+
+
+class URLs(bases.Model):
+    class Config:
+        frozen = True
+
+    _entity_name: str = "projects/{project_id}/datasets/{el_name}"
+    list: str = f"{_entity_name}/entities"
+    post: str = f"{_entity_name}/entities"
+    get_table: str = f"{_entity_name}.svc/Entities"
+
+
+class EntityService(bases.Service):
+    """
+    Entity-related functionality is accessed through `client.entities`. For example:
+
+    ```python
+    from pyodk.client import Client
+
+    client = Client()
+    data = client.entities.list()
+    ```
+
+    An EntityList is a list of Entities, e.g. `list[Entity]`.
+    """
+
+    __slots__ = ("urls", "session", "default_project_id", "default_entity_list_name")
+
+    def __init__(
+        self,
+        session: Session,
+        default_project_id: int | None = None,
+        default_entity_list_name: str | None = None,
+        urls: URLs = None,
+    ):
+        self.urls: URLs = urls if urls is not None else URLs()
+        self.session: Session = session
+        self.default_project_id: int | None = default_project_id
+        self.default_entity_list_name: str | None = default_entity_list_name
+
+    def list(
+        self, entity_list_name: str | None = None, project_id: int | None = None
+    ) -> list[Entity]:
+        """
+        Read all Entity metadata.
+
+        :param entity_list_name: The name of the Entity List (Dataset) being referenced.
+        :param project_id: The id of the project the Entity belongs to.
+
+        :return: A list of the object representation of all Entity metadata.
+        """
+        try:
+            pid = pv.validate_project_id(project_id, self.default_project_id)
+            eln = pv.validate_entity_list_name(
+                entity_list_name, self.default_entity_list_name
+            )
+        except PyODKError as err:
+            log.error(err, exc_info=True)
+            raise
+
+        response = self.session.response_or_error(
+            method="GET",
+            url=self.session.urlformat(self.urls.list, project_id=pid, el_name=eln),
+            logger=log,
+        )
+        data = response.json()
+        return [Entity(**r) for r in data]
+
+    def create(
+        self,
+        label: str,
+        data: dict,
+        entity_list_name: str | None = None,
+        project_id: int | None = None,
+        uuid: str | None = None,
+    ) -> Entity:
+        """
+        Create an Entity.
+
+        :param label: Label of the Entity.
+        :param data: Data to store for the Entity.
+        :param entity_list_name: The name of the Entity List (Dataset) being referenced.
+        :param project_id: The id of the project this form belongs to.
+        :param uuid: An optional unique identifier for the Entity. If not provided then
+          a uuid will be generated and sent by the client.
+        """
+        try:
+            pid = pv.validate_project_id(project_id, self.default_project_id)
+            eln = pv.validate_entity_list_name(
+                entity_list_name, self.default_entity_list_name
+            )
+            req_data = {
+                "uuid": pv.validate_str(uuid, str(uuid4()), key="uuid"),
+                "label": pv.validate_str(label, key="label"),
+                "data": pv.validate_dict(data, key="data"),
+            }
+        except PyODKError as err:
+            log.error(err, exc_info=True)
+            raise
+
+        response = self.session.response_or_error(
+            method="POST",
+            url=self.session.urlformat(self.urls.post, project_id=pid, el_name=eln),
+            logger=log,
+            data=req_data,
+        )
+        data = response.json()
+        return Entity(**data)
+
+    def get_table(
+        self,
+        entity_list_name: str | None = None,
+        project_id: int | None = None,
+        skip: int | None = None,
+        top: int | None = None,
+        count: bool | None = None,
+        filter: str | None = None,
+        select: str | None = None,
+    ) -> dict:
+        """
+        Read Entity List data.
+
+        :param entity_list_name: The name of the Entity List (Dataset) being referenced.
+        :param project_id: The id of the project this form belongs to.
+        :param skip: The first n rows will be omitted from the results.
+        :param top: Only up to n rows will be returned in the results.
+        :param count: If True, an @odata.count property will be added to the result to
+          indicate the total number of rows, ignoring the above paging parameters.
+        :param filter: Filter responses to those matching the query. Only certain fields
+          are available to reference. The operators lt, le, eq, neq, ge, gt, not, and,
+          and or are supported, and the built-in functions now, year, month, day, hour,
+          minute, second.
+        :param select: If provided, will return only the selected fields.
+
+        :return: A dictionary representation of the OData JSON document.
+        """
+        try:
+            pid = pv.validate_project_id(project_id, self.default_project_id)
+            eln = pv.validate_entity_list_name(
+                entity_list_name, self.default_entity_list_name
+            )
+            params = {
+                k: v
+                for k, v in {
+                    "$skip": skip,
+                    "$top": top,
+                    "$count": count,
+                    "$filter": filter,
+                    "$select": select,
+                }.items()
+                if v is not None
+            }
+        except PyODKError as err:
+            log.error(err, exc_info=True)
+            raise
+
+        response = self.session.response_or_error(
+            method="GET",
+            url=self.session.urlformat(
+                self.urls.get_table, project_id=pid, el_name=eln, table_name="Entities"
+            ),
+            logger=log,
+            params=params,
+        )
+        return response.json()

--- a/pyodk/_endpoints/entity_lists.py
+++ b/pyodk/_endpoints/entity_lists.py
@@ -36,12 +36,8 @@ class EntityListService(bases.Service):
     data = client.entity_lists.list()
     ```
 
-    The structure this class works with is conceptually a list of lists, e.g.
-
-    ```
-    EntityList = list[Entity]
-    self.list() = list[EntityList]
-    ```
+    Conceptually, an EntityList's parent object is a Project. Each Project may have
+    multiple EntityLists.
     """
 
     __slots__ = ("urls", "session", "default_project_id")

--- a/pyodk/_endpoints/entity_lists.py
+++ b/pyodk/_endpoints/entity_lists.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import datetime
+
+from pyodk._endpoints import bases
+from pyodk._utils import validators as pv
+from pyodk._utils.session import Session
+from pyodk.errors import PyODKError
+
+log = logging.getLogger(__name__)
+
+
+class EntityList(bases.Model):
+    name: str
+    projectId: int
+    createdAt: datetime
+    approvalRequired: bool
+
+
+class URLs(bases.Model):
+    class Config:
+        frozen = True
+
+    list: str = "projects/{project_id}/datasets"
+
+
+class EntityListService(bases.Service):
+    """
+    Entity List-related functionality is accessed through `client.entity_lists`.
+
+    For example:
+
+    ```python
+    from pyodk.client import Client
+
+    client = Client()
+    data = client.entity_lists.list()
+    ```
+
+    The structure this class works with is conceptually a list of lists, e.g.
+
+    ```
+    EntityList = list[Entity]
+    self.list() = list[EntityList]
+    ```
+    """
+
+    __slots__ = ("urls", "session", "default_project_id")
+
+    def __init__(
+        self,
+        session: Session,
+        default_project_id: int | None = None,
+        urls: URLs = None,
+    ):
+        self.urls: URLs = urls if urls is not None else URLs()
+        self.session: Session = session
+        self.default_project_id: int | None = default_project_id
+
+    def list(self, project_id: int | None = None) -> list[EntityList]:
+        """
+        Read Entity List details.
+
+        :param project_id: The id of the project the Entity List belongs to.
+
+        :return: A list of the object representation of all Entity Lists' details.
+        """
+        try:
+            pid = pv.validate_project_id(project_id, self.default_project_id)
+        except PyODKError as err:
+            log.error(err, exc_info=True)
+            raise
+
+        response = self.session.response_or_error(
+            method="GET",
+            url=self.session.urlformat(self.urls.list, project_id=pid),
+            logger=log,
+        )
+        data = response.json()
+        return [EntityList(**r) for r in data]

--- a/pyodk/_endpoints/projects.py
+++ b/pyodk/_endpoints/projects.py
@@ -128,7 +128,7 @@ class ProjectService(bases.Service):
         # The "App User" role_id should always be "2", so no need to look it up by name.
         # Ref: "https://github.com/getodk/central-backend/blob/9db0d792cf4640ec7329722984
         #   cebdee3687e479/lib/model/migrations/20181212-01-add-roles.js"
-        # See also roles data in `tests/resorces/projects_data.py`.
+        # See also roles data in `tests/resources/projects_data.py`.
         if forms is not None:
             for user in users:
                 for form_id in forms:

--- a/pyodk/_utils/validators.py
+++ b/pyodk/_utils/validators.py
@@ -57,6 +57,14 @@ def validate_instance_id(*args: str) -> str:
     )
 
 
+def validate_entity_list_name(*args: str) -> str:
+    return wrap_error(
+        validator=v.str_validator,
+        key="entity_list_name",
+        value=coalesce(*args),
+    )
+
+
 def validate_str(*args: str, key: str) -> str:
     return wrap_error(
         validator=v.str_validator,
@@ -76,6 +84,14 @@ def validate_bool(*args: bool, key: str) -> str:
 def validate_int(*args: int, key: str) -> int:
     return wrap_error(
         validator=v.int_validator,
+        key=key,
+        value=coalesce(*args),
+    )
+
+
+def validate_dict(*args: dict, key: str) -> int:
+    return wrap_error(
+        validator=v.dict_validator,
         key=key,
         value=coalesce(*args),
     )

--- a/pyodk/client.py
+++ b/pyodk/client.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 
 from pyodk._endpoints.comments import CommentService
+from pyodk._endpoints.entities import EntityService
+from pyodk._endpoints.entity_lists import EntityListService
 from pyodk._endpoints.forms import FormService
 from pyodk._endpoints.projects import ProjectService
 from pyodk._endpoints.submissions import SubmissionService
@@ -65,6 +67,12 @@ class Client:
             session=self.session, default_project_id=self.project_id
         )
         self._comments: CommentService = CommentService(
+            session=self.session, default_project_id=self.project_id
+        )
+        self.entities: EntityService = EntityService(
+            session=self.session, default_project_id=self.project_id
+        )
+        self.entity_lists: EntityListService = EntityListService(
             session=self.session, default_project_id=self.project_id
         )
 

--- a/tests/endpoints/test_entities.py
+++ b/tests/endpoints/test_entities.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from pyodk._endpoints.entities import Entity
+from pyodk._utils.session import Session
+from pyodk.client import Client
+
+from tests.resources import CONFIG_DATA, entities_data
+
+
+@patch("pyodk._utils.session.Auth.login", MagicMock())
+@patch("pyodk._utils.config.read_config", MagicMock(return_value=CONFIG_DATA))
+class TestEntities(TestCase):
+    def test_list__ok(self):
+        """Should return a list of Entity objects."""
+        fixture = entities_data.test_entities
+        with patch.object(Session, "request") as mock_session:
+            mock_session.return_value.status_code = 200
+            mock_session.return_value.json.return_value = fixture
+            with Client() as client:
+                observed = client.entities.list(entity_list_name="test")
+        self.assertEqual(2, len(observed))
+        for i, o in enumerate(observed):
+            with self.subTest(i):
+                self.assertIsInstance(o, Entity)
+
+    def test_create__ok(self):
+        """Should return an Entity object."""
+        fixture = entities_data.test_entities
+        with patch.object(Session, "request") as mock_session:
+            mock_session.return_value.status_code = 200
+            mock_session.return_value.json.return_value = fixture[0]
+            with Client() as client:
+                # Specify project
+                observed = client.entities.create(
+                    project_id=2,
+                    entity_list_name="test",
+                    label="John (88)",
+                    data=entities_data.test_entities_data,
+                )
+                self.assertIsInstance(observed, Entity)
+                # Use default
+                observed = client.entities.create(
+                    entity_list_name="test",
+                    label="John (88)",
+                    data=entities_data.test_entities_data,
+                )
+                self.assertIsInstance(observed, Entity)

--- a/tests/endpoints/test_entity_lists.py
+++ b/tests/endpoints/test_entity_lists.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from pyodk._endpoints.entity_lists import EntityList
+from pyodk._utils.session import Session
+from pyodk.client import Client
+
+from tests.resources import CONFIG_DATA, entity_lists_data
+
+
+@patch("pyodk._utils.session.Auth.login", MagicMock())
+@patch("pyodk._utils.config.read_config", MagicMock(return_value=CONFIG_DATA))
+class TestEntityLists(TestCase):
+    def test_list__ok(self):
+        """Should return a list of EntityList objects."""
+        fixture = entity_lists_data.test_entity_lists
+        with patch.object(Session, "request") as mock_session:
+            mock_session.return_value.status_code = 200
+            mock_session.return_value.json.return_value = fixture
+            with Client() as client:
+                observed = client.entity_lists.list()
+        self.assertEqual(2, len(observed))
+        for i, o in enumerate(observed):
+            with self.subTest(i):
+                self.assertIsInstance(o, EntityList)

--- a/tests/resources/entities_data.py
+++ b/tests/resources/entities_data.py
@@ -1,0 +1,41 @@
+test_entities = [
+    {
+        "uuid": "uuid:85cb9aff-005e-4edd-9739-dc9c1a829c44",
+        "createdAt": "2018-01-19T23:58:03.395Z",
+        "updatedAt": "2018-03-21T12:45:02.312Z",
+        "deletedAt": "2018-03-21T12:45:02.312Z",
+        "creatorId": 1,
+        "currentVersion": {
+            "label": "John (88)",
+            "current": True,
+            "createdAt": "2018-03-21T12:45:02.312Z",
+            "creatorId": 1,
+            "userAgent": "Enketo/3.0.4",
+            "version": 1,
+            "baseVersion": None,
+            "conflictingProperties": None,
+        },
+    },
+    {
+        "uuid": "uuid:85cb9aff-005e-4edd-9739-dc9c1a829c45",
+        "createdAt": "2018-01-19T23:58:03.395Z",
+        "updatedAt": "2018-03-21T12:45:02.312Z",
+        "deletedAt": "2018-03-21T12:45:02.312Z",
+        "creatorId": 1,
+        "conflict": "soft",
+        "currentVersion": {
+            "label": "John (89)",
+            "current": True,
+            "createdAt": "2018-03-21T12:45:02.312Z",
+            "creatorId": 1,
+            "userAgent": "Enketo/3.0.4",
+            "version": 1,
+            "baseVersion": None,
+            "conflictingProperties": None,
+        },
+    },
+]
+test_entities_data = {
+    "firstName": "John",
+    "age": "88",
+}

--- a/tests/resources/entity_lists_data.py
+++ b/tests/resources/entity_lists_data.py
@@ -1,0 +1,14 @@
+test_entity_lists = [
+    {
+        "name": "people",
+        "createdAt": "2018-01-19T23:58:03.395Z",
+        "projectId": 1,
+        "approvalRequired": True,
+    },
+    {
+        "name": "places",
+        "createdAt": "2018-01-19T23:58:03.396Z",
+        "projectId": 1,
+        "approvalRequired": False,
+    },
+]

--- a/tests/utils/entity_lists.py
+++ b/tests/utils/entity_lists.py
@@ -1,0 +1,48 @@
+from pyodk._endpoints.entity_lists import EntityList, log
+from pyodk.client import Client
+from pyodk.errors import PyODKError
+
+
+def create_new_or_get_entity_list(
+    client: Client, entity_list_name: str, entity_props: list[str]
+) -> EntityList:
+    """
+    Create a new entity list, or get the entity list metadata.
+
+    :param client: Client instance to use for API calls.
+    :param entity_list_name: Name of the entity list.
+    :param entity_props: Properties to add to the entity list.
+    """
+    try:
+        entity_list = client.session.response_or_error(
+            method="POST",
+            url=client.session.urlformat(
+                "projects/{pid}/datasets",
+                pid=client.project_id,
+            ),
+            logger=log,
+            json={"name": entity_list_name},
+        )
+    except PyODKError:
+        entity_list = client.session.get(
+            url=client.session.urlformat(
+                "projects/{pid}/datasets/{eln}",
+                pid=client.project_id,
+                eln=entity_list_name,
+            ),
+        )
+    try:
+        for prop in entity_props:
+            client.session.response_or_error(
+                method="GET",
+                url=client.session.urlformat(
+                    "projects/{pid}/datasets/{eln}/properties",
+                    pid=client.project_id,
+                    eln=entity_list_name,
+                ),
+                logger=log,
+                json={"name": prop},
+            )
+    except PyODKError:
+        pass
+    return EntityList(**entity_list.json())


### PR DESCRIPTION
Closes #62

Adds methods:
- client.entity_lists.list
- client.entities.list
- client.entities.create
- client.entities.get_table

Other entity_lists methods in #62 not included as they aren't publicly documented yet, so I don't know what the proper call pattern or response type/schema is. Although I took a guess based on manual testing for the test setup function in `tests/utils/entity_lists.py`.

#### What has been done to verify that this works as intended?

E2E tests added to `test_client.py` as well as usual unit tests.

#### Why is this the best possible solution? Were any other approaches considered?

I split entities from entity_lists, because they are separate object types. Due to the similar names it was confusing for me initially to tell the difference between an entity and entity_list and what they are supposed to do. Especially considering `entity.list()`, `entity_list.list()`. So the docstrings for EntityService and EntityListService try to clarify the difference.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shiny new features!

#### Do we need any specific form for testing your changes? If so, please attach one.

No it's automated in `test_client.py`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

The auto-generated docs is a good start but maybe we should add a notebook or something once the extra entity_list methods are available. Something like `test_client.py`/`test_entities__create_and_query` but more elaborate and relatable.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
