### PR TITLE
Update example dependencies, recommend pyenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library aims to make common data analysis and workflow automation tasks as 
 
 ## Install
 
-The currently supported Python version for `pyodk` is 3.12.
+The currently supported Python version for `pyodk` is 3.12. We recommend using [`pyenv`](https://github.com/pyenv/pyenv) to manage multiple versions of Python.
 
 ### From pip
 
@@ -24,7 +24,7 @@ cd ~/repos/pyodk
 git clone https://github.com/getodk/pyodk.git repo
 
 # Create and activate a virtual environment for the install.
-/usr/local/bin/python3.8 -m venv venv
+python -m venv venv
 source venv/bin/activate
 
 # Install pyodk and its production dependencies.

--- a/docs/examples/app_user_provisioner/requirements.txt
+++ b/docs/examples/app_user_provisioner/requirements.txt
@@ -1,3 +1,3 @@
-pyodk==0.2.0
-segno==1.5.2
-Pillow==9.4.0
+pyodk==0.3.0
+segno==1.6.1
+Pillow==10.3.0


### PR DESCRIPTION
The intent for the app user provisioner example is for it to be a standalone script. I considered briefly whether it would make sense to introduce a pyproject.toml file for it but from https://stackoverflow.com/a/76548420/137744 decided requirements.txt was the most appropriate for pinned dependencies.

That led me to wonder a bit about the top-level pyproject.toml file and whether it should include pinned versions or not. I don't think it's a big deal because we don't know of anyone packaging pyodk as part of a larger system but we may want to eventually separate declared dependencies and pinned versions.

I also noticed that the readme mentions python 3.8 which it should not. @lindsay-stevens do you use `pyenv`? Happy to recommend something else if you prefer (but I do 💜 `pyenv`!).