### PR TITLE
60: add form creation

### DIFF
--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime
-from uuid import uuid4
 
 from pyodk._endpoints import bases
 from pyodk._utils import validators as pv
@@ -121,7 +120,7 @@ class EntityService(bases.Service):
                 entity_list_name, self.default_entity_list_name
             )
             req_data = {
-                "uuid": pv.validate_str(uuid, str(uuid4()), key="uuid"),
+                "uuid": pv.validate_str(uuid, self.session.get_xform_uuid(), key="uuid"),
                 "label": pv.validate_str(label, key="label"),
                 "data": pv.validate_dict(data, key="data"),
             }

--- a/pyodk/_endpoints/form_draft_attachments.py
+++ b/pyodk/_endpoints/form_draft_attachments.py
@@ -1,5 +1,5 @@
 import logging
-from pathlib import Path
+from os import PathLike
 
 from pyodk._endpoints import bases
 from pyodk._utils import validators as pv
@@ -34,7 +34,7 @@ class FormDraftAttachmentService(bases.Service):
 
     def upload(
         self,
-        file_path: str,
+        file_path: PathLike | str,
         file_name: str | None = None,
         form_id: str | None = None,
         project_id: int | None = None,
@@ -50,7 +50,7 @@ class FormDraftAttachmentService(bases.Service):
         try:
             pid = pv.validate_project_id(project_id, self.default_project_id)
             fid = pv.validate_form_id(form_id, self.default_form_id)
-            file_path = Path(pv.validate_file_path(file_path))
+            file_path = pv.validate_file_path(file_path)
             if file_name is None:
                 file_name = pv.validate_str(file_path.name, key="file_name")
         except PyODKError as err:

--- a/pyodk/_endpoints/form_drafts.py
+++ b/pyodk/_endpoints/form_drafts.py
@@ -1,6 +1,7 @@
 import logging
-from contextlib import nullcontext
-from pathlib import Path
+from io import BytesIO
+from os import PathLike
+from zipfile import is_zipfile
 
 from pyodk._endpoints import bases
 from pyodk._utils import validators as pv
@@ -8,6 +9,76 @@ from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
 
 log = logging.getLogger(__name__)
+CONTENT_TYPES = {
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".xls": "application/vnd.ms-excel",
+    ".xml": "application/xml",
+}
+
+
+def is_xls_file(buf: bytes) -> bool:
+    """
+    Implements the Microsoft Excel (Office 97-2003) document type matcher.
+
+    From h2non/filetype v1.2.0, MIT License, Copyright (c) 2016 Tomás Aparicio
+
+    :param buf: buffer to match against.
+    """
+    if len(buf) > 520 and buf[0:8] == b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1":
+        if buf[512:516] == b"\xfd\xff\xff\xff" and (buf[518] == 0x00 or buf[518] == 0x02):
+            return True
+        if buf[512:520] == b"\x09\x08\x10\x00\x00\x06\x05\x00":
+            return True
+        if (
+            len(buf) > 2095
+            and b"\xe2\x00\x00\x00\x5c\x00\x70\x00\x04\x00\x00Calc" in buf[1568:2095]
+        ):
+            return True
+
+    return False
+
+
+def get_definition_data(
+    definition: PathLike | str | bytes | None,
+) -> (bytes, str, str | None):
+    """
+    Get the form definition data from a path or bytes.
+
+    :param definition: The path to the file to upload (string or PathLike), or the
+          form definition in memory (string (XML) or bytes (XLS/XLSX)).
+    :return: definition_data, content_type, file_path_stem (if any).
+    """
+    definition_data = None
+    content_type = None
+    file_path_stem = None
+    if (
+        isinstance(definition, str)
+        and """http://www.w3.org/2002/xforms""" in definition[:1000]
+    ):
+        content_type = CONTENT_TYPES[".xml"]
+        definition_data = definition.encode("utf-8")
+    elif isinstance(definition, str | PathLike):
+        file_path = pv.validate_file_path(definition)
+        file_path_stem = file_path.stem
+        definition_data = file_path.read_bytes()
+        if file_path.suffix not in CONTENT_TYPES:
+            raise PyODKError(
+                "Parameter 'definition' file name has an unexpected file extension, "
+                "expected one of '.xlsx', '.xls', '.xml'."
+            )
+        content_type = CONTENT_TYPES[file_path.suffix]
+    elif isinstance(definition, bytes):
+        definition_data = definition
+        if is_zipfile(BytesIO(definition)):
+            content_type = CONTENT_TYPES[".xlsx"]
+        elif is_xls_file(definition):
+            content_type = CONTENT_TYPES[".xls"]
+    if definition_data is None or content_type is None:
+        raise PyODKError(
+            "Parameter 'definition' has an unexpected file type, "
+            "expected one of '.xlsx', '.xls', '.xml'."
+        )
+    return definition_data, content_type, file_path_stem
 
 
 class URLs(bases.Model):
@@ -36,15 +107,16 @@ class FormDraftService(bases.Service):
 
     def _prep_form_post(
         self,
-        file_path: Path | str | None = None,
+        definition: PathLike | str | bytes | None = None,
         ignore_warnings: bool | None = True,
         form_id: str | None = None,
         project_id: int | None = None,
-    ) -> (str, str, dict, dict):
+    ) -> (str, str, dict, dict, bytes | None):
         """
         Prepare / validate input arguments for POSTing a new form definition or version.
 
-        :param file_path: The path to the file to upload.
+        :param definition: The path to the file to upload (string or PathLike), or the
+          form definition in memory (string (XML) or bytes (XLS/XLSX)).
         :param form_id: The xmlFormId of the Form being referenced.
         :param project_id: The id of the project this form belongs to.
         :param ignore_warnings: If True, create the form if there are XLSForm warnings.
@@ -54,47 +126,33 @@ class FormDraftService(bases.Service):
             pid = pv.validate_project_id(project_id, self.default_project_id)
             headers = {}
             params = {}
+            definition_data = None
             file_path_stem = None
-            if file_path is not None:
-                file_path = Path(pv.validate_file_path(file_path))
-                file_path_stem = file_path.stem
+            if definition is not None:
+                definition_data, content_type, file_path_stem = get_definition_data(
+                    definition=definition
+                )
+                headers["Content-Type"] = content_type
             fid = pv.validate_form_id(
                 form_id,
                 self.default_form_id,
                 file_path_stem,
                 self.session.get_xform_uuid(),
             )
-            if file_path is not None:
+            if definition is not None:
                 if ignore_warnings is not None:
                     key = "ignore_warnings"
                     params["ignoreWarnings"] = pv.validate_bool(ignore_warnings, key=key)
-                if file_path.suffix == ".xlsx":
-                    content_type = (
-                        "application/vnd.openxmlformats-"
-                        "officedocument.spreadsheetml.sheet"
-                    )
-                elif file_path.suffix == ".xls":
-                    content_type = "application/vnd.ms-excel"
-                elif file_path.suffix == ".xml":
-                    content_type = "application/xml"
-                else:
-                    raise PyODKError(  # noqa: TRY301
-                        "Parameter 'file_path' file name has an unexpected extension, "
-                        "expected one of '.xlsx', '.xls', '.xml'."
-                    )
-                headers = {
-                    "Content-Type": content_type,
-                    "X-XlsForm-FormId-Fallback": self.session.urlquote(fid),
-                }
+                headers["X-XlsForm-FormId-Fallback"] = self.session.urlquote(fid)
         except PyODKError as err:
             log.error(err, exc_info=True)
             raise
 
-        return pid, fid, headers, params
+        return pid, fid, headers, params, definition_data
 
     def create(
         self,
-        file_path: Path | str | None = None,
+        definition: PathLike | str | bytes | None = None,
         ignore_warnings: bool | None = True,
         form_id: str | None = None,
         project_id: int | None = None,
@@ -102,28 +160,26 @@ class FormDraftService(bases.Service):
         """
         Create a Form Draft.
 
-        :param file_path: The path to the file to upload.
+        :param definition: The path to the file to upload (string or PathLike), or the
+          form definition in memory (string (XML) or bytes (XLS/XLSX)).
         :param form_id: The xmlFormId of the Form being referenced.
         :param project_id: The id of the project this form belongs to.
         :param ignore_warnings: If True, create the form if there are XLSForm warnings.
         """
-        pid, fid, headers, params = self._prep_form_post(
-            file_path=file_path,
+        pid, fid, headers, params, form_def = self._prep_form_post(
+            definition=definition,
             ignore_warnings=ignore_warnings,
             form_id=form_id,
             project_id=project_id,
         )
-
-        with open(file_path, "rb") if file_path is not None else nullcontext() as fd:
-            response = self.session.response_or_error(
-                method="POST",
-                url=self.session.urlformat(self.urls.post, project_id=pid, form_id=fid),
-                logger=log,
-                headers=headers,
-                params=params,
-                data=fd,
-            )
-
+        response = self.session.response_or_error(
+            method="POST",
+            url=self.session.urlformat(self.urls.post, project_id=pid, form_id=fid),
+            logger=log,
+            headers=headers,
+            params=params,
+            data=form_def,
+        )
         data = response.json()
         return data["success"]
 

--- a/pyodk/_utils/session.py
+++ b/pyodk/_utils/session.py
@@ -2,6 +2,7 @@ from logging import Logger
 from string import Formatter
 from typing import Any
 from urllib.parse import quote, urljoin
+from uuid import uuid4
 
 from requests import PreparedRequest, Response
 from requests import Session as RequestsSession
@@ -159,3 +160,10 @@ class Session(RequestsSession):
             raise err from e
         else:
             return response
+
+    @staticmethod
+    def get_xform_uuid() -> str:
+        """
+        Get XForm UUID, which is "uuid:" followed by a random uuid v4.
+        """
+        return f"uuid:{uuid4()}"

--- a/pyodk/_utils/validators.py
+++ b/pyodk/_utils/validators.py
@@ -1,8 +1,10 @@
 from collections.abc import Callable
+from os import PathLike
 from pathlib import Path
 from typing import Any
 
 from pydantic.v1 import validators as v
+from pydantic.v1.errors import PydanticValueError
 from pydantic_core._pydantic_core import ValidationError
 
 from pyodk._utils.utils import coalesce
@@ -20,7 +22,7 @@ def wrap_error(validator: Callable, key: str, value: Any) -> Any:
     """
     try:
         return validator(value)
-    except ValidationError as err:
+    except (ValidationError, PydanticValueError) as err:
         msg = f"{key}: {err!s}"
         raise PyODKError(msg) from err
 
@@ -97,7 +99,7 @@ def validate_dict(*args: dict, key: str) -> int:
     )
 
 
-def validate_file_path(*args: str) -> Path:
+def validate_file_path(*args: PathLike | str) -> Path:
     def validate_fp(f):
         p = v.path_validator(f)
         return v.path_exists_validator(p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
 # Install with `pip install pyodk[dev]`.
 dev = [
     "ruff==0.3.4",        # Format and lint
-    "openpyxl==3.1.2"     # Create test XLSX files
+    "openpyxl==3.1.2",    # Create test XLSX files
+    "xlwt==1.3.0",        # Create test XLS files
 ]
 docs = [
     "mkdocs==1.5.3",

--- a/tests/resources/forms/range_draft.xml
+++ b/tests/resources/forms/range_draft.xml
@@ -8,7 +8,7 @@
         <h:title>range_draft</h:title>
         <model odk:xforms-version="1.0.0">
             <instance>
-                <data id="range_draft" version="{version}">
+                <data id="{form_id}" version="{version}">
                     <start/>
                     <end/>
                     <Enter_a_number_within_a_specified_range/>

--- a/tests/resources/forms_data.py
+++ b/tests/resources/forms_data.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 test_forms = {
@@ -76,11 +76,13 @@ test_forms = {
 }
 
 
-def get_xml__range_draft(version: str | None = None) -> str:
+def get_xml__range_draft(
+    form_id: str | None = "range_draft", version: str | None = None
+) -> str:
     if version is None:
-        version = datetime.now().isoformat()
+        version = datetime.now(UTC).isoformat()
     with open(Path(__file__).parent / "forms" / "range_draft.xml") as fd:
-        return fd.read().format(version=version)
+        return fd.read().format(form_id=form_id, version=version)
 
 
 def get_md__pull_data(version: str | None = None) -> str:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -124,6 +124,24 @@ class TestUsage(TestCase):
             forms = client.forms.list()
         print(projects, forms)
 
+    def test_form_create__new_definition_xml(self):
+        """Should create a new form with the new definition."""
+        form_id = self.client.session.get_xform_uuid()
+        with utils.get_temp_file(suffix=".xml") as fp:
+            fp.write_text(forms_data.get_xml__range_draft(form_id=form_id))
+            self.client.forms.create(
+                form_id=form_id,
+                definition=fp.as_posix(),
+            )
+
+    def test_form_create__new_definition_xlsx(self):
+        """Should create a new form with the new definition."""
+        form_id = "no_form_id"
+        form_def = forms_data.get_md__pull_data()
+        with md_table_to_temp_dir(form_id=form_id, mdstr=form_def) as fp:
+            form = self.client.forms.create(definition=fp.as_posix())
+        self.assertTrue(form.xmlFormId.startswith("uuid:"))
+
     # Below tests assume project has forms by these names already published.
     def test_form_update__new_definition(self):
         """Should create a new version with the new definition."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ from tests.utils.forms import (
     create_new_form__xml,
     get_latest_form_version,
 )
-from tests.utils.md_table import md_table_to_temp_dir
+from tests.utils.md_table import md_table_to_bytes, md_table_to_temp_dir
 from tests.utils.submissions import (
     create_new_or_get_last_submission,
     create_or_update_submission_with_comment,
@@ -127,19 +127,16 @@ class TestUsage(TestCase):
     def test_form_create__new_definition_xml(self):
         """Should create a new form with the new definition."""
         form_id = self.client.session.get_xform_uuid()
-        with utils.get_temp_file(suffix=".xml") as fp:
-            fp.write_text(forms_data.get_xml__range_draft(form_id=form_id))
-            self.client.forms.create(
-                form_id=form_id,
-                definition=fp.as_posix(),
-            )
+        self.client.forms.create(
+            form_id=form_id,
+            definition=forms_data.get_xml__range_draft(form_id=form_id),
+        )
 
     def test_form_create__new_definition_xlsx(self):
         """Should create a new form with the new definition."""
-        form_id = "no_form_id"
         form_def = forms_data.get_md__pull_data()
-        with md_table_to_temp_dir(form_id=form_id, mdstr=form_def) as fp:
-            form = self.client.forms.create(definition=fp.as_posix())
+        wb = md_table_to_bytes(mdstr=form_def)
+        form = self.client.forms.create(definition=wb)
         self.assertTrue(form.xmlFormId.startswith("uuid:"))
 
     # Below tests assume project has forms by these names already published.

--- a/tests/utils/forms.py
+++ b/tests/utils/forms.py
@@ -1,40 +1,8 @@
-from pathlib import Path
-from typing import IO
-
-from pyodk._endpoints.form_drafts import FormDraftService
 from pyodk.client import Client
 from pyodk.errors import PyODKError
 
 from tests.utils import utils
 from tests.utils.md_table import md_table_to_temp_dir
-
-
-def create_new_form(client: Client, file_path: Path | str, form_id: str, form_data: IO):
-    """
-    Create a new form. Ignores any pyODK errors.
-
-    :param client: Client instance to use for API calls.
-    :param file_path: Path of the form definition.
-    :param form_id: The xmlFormId of the Form being referenced.
-    :param form_data: The form file descriptor which can be read() from.
-    :return:
-    """
-    try:
-        fd = FormDraftService(
-            session=client.session, default_project_id=client.project_id
-        )
-        pid, fid, headers, params = fd._prep_form_post(
-            file_path=file_path, form_id=form_id
-        )
-        params["publish"] = True
-        client.post(
-            url=client.session.urlformat("projects/{pid}/forms", pid=client.project_id),
-            headers=headers,
-            params=params,
-            data=form_data,
-        )
-    except PyODKError:
-        pass
 
 
 def create_new_form__md(client: Client, form_id: str, form_def: str):
@@ -47,9 +15,11 @@ def create_new_form__md(client: Client, form_id: str, form_def: str):
     """
     with (
         md_table_to_temp_dir(form_id=form_id, mdstr=form_def) as fp,
-        open(fp, "rb") as form_data,
     ):
-        create_new_form(client=client, file_path=fp, form_id=form_id, form_data=form_data)
+        try:
+            client.forms.create(definition=fp, form_id=form_id)
+        except PyODKError:
+            pass
 
 
 def create_new_form__xml(client: Client, form_id: str, form_def: str):
@@ -62,10 +32,10 @@ def create_new_form__xml(client: Client, form_id: str, form_def: str):
     """
     with utils.get_temp_file(suffix=".xml") as fp:
         fp.write_text(form_def)
-        with open(fp, "rb") as form_data:
-            create_new_form(
-                client=client, file_path=fp, form_id=form_id, form_data=form_data
-            )
+        try:
+            client.forms.create(definition=fp, form_id=form_id)
+        except PyODKError:
+            pass
 
 
 def get_latest_form_version(client: Client, form_id: str) -> str:

--- a/tests/utils/md_table.py
+++ b/tests/utils/md_table.py
@@ -4,9 +4,11 @@ Markdown table utility functions.
 
 import re
 from contextlib import contextmanager
+from io import BytesIO
 from pathlib import Path
 
 from openpyxl import Workbook
+from xlwt import Workbook as XLSWorkbook
 
 from tests.utils.utils import get_temp_dir
 
@@ -88,3 +90,35 @@ def md_table_to_temp_dir(form_id: str, mdstr: str) -> Path:
         fp = Path(td) / f"{form_id}.xlsx"
         md_table_to_workbook(mdstr).save(fp.as_posix())
         yield fp
+
+
+def md_table_to_bytes(mdstr: str) -> bytes:
+    """
+    Convert MarkDown table string to XLSX Workbook bytes.
+
+    :param mdstr: The MarkDown table string.
+    """
+    wb = md_table_to_workbook(mdstr=mdstr)
+    fd = BytesIO()
+    wb.save(fd)
+    fd.seek(0)
+    return fd.getvalue()
+
+
+def md_table_to_bytes_xls(mdstr: str) -> bytes:
+    """
+    Convert MarkDown table string to XLS Workbook bytes.
+
+    :param mdstr: The MarkDown table string.
+    """
+    md_data = md_table_to_ss_structure(mdstr=mdstr)
+    wb = XLSWorkbook()
+    for key, rows in md_data:
+        sheet = wb.add_sheet(sheetname=key)
+        for ir, row in enumerate(rows):
+            for ic, cell in enumerate(row):
+                sheet.write(ir, ic, cell)
+    fd = BytesIO()
+    wb.save(fd)
+    fd.seek(0)
+    return fd.getvalue()


### PR DESCRIPTION
Closes #60

Adds method `client.forms.create`. There is a parameter for ignore_warnings which defaults to False. The publish parameter is hard coded to True as per #60. The form ID logic is slightly different, as follows - since pyODK has a form_id param and potentially a file path it seemed sensible to prioritise those before a uuid-based form ID fallback.

form_id defaults behaviour for create/update:
  - was:
    - form_id in the file (assuming Central reads and prioritises that)
    - definition file_path.stem
  - now:
    - form_id in the file (assuming Central reads and prioritises that)
    - form_id (or default) provided to pyodk
    - definition file_path.stem
    - random UUID

Also since I anticipated this being used in pyxform-http or similar I made create/update accept bytes. So you could read in the request and send it off without writing to a file. I didn't add that for attachments but it could be done as well. I also had in mind Sam from HOT's recent request for pyxform to support passing in bytes in addition to paths.

#### What has been done to verify that this works as intended?

Unit tests and E2E tests. Manually verified valid forms were uploaded.

#### Why is this the best possible solution? Were any other approaches considered?

If the bytes thing seems too much, it's pretty much contained to 36fe156 so that could be dropped if preferred.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

New method to create forms. For update, the `definition` kwarg now accepts PathLike or bytes in addition to a string path.

#### Do we need any specific form for testing your changes? If so, please attach one.

No, this PR pulls in `xlwt` as a dependency for XLS files so we can steadfastly not add binary test fixtures. On the XLS topic, I vendorised (but credited in comments) an external XLS detection function.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

The auto-generated docs would show the new methods.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
