### PR TITLE
73: add client.entities.update

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ The `Client` is not specific to a project, but a default `project_id` can be set
 - An init argument: `Client(project_id=1)`.
 - A property on the client: `client.project_id = 1`.
 
+*Default Identifiers*
+
+For each endpoint, a default can be set for key identifiers, so these identifiers are optional in most methods. When the identifier is required, validation ensures that either a default value is set, or a value is specified. E.g.
+
+```python
+client.projects.default_project_id = 1
+client.forms.default_form_id = "my_form"
+client.submissions.default_form_id = "my_form"
+client.entities.default_entity_list_name = "my_list"
+client.entities.default_project_id = 1
+```
+
 ### Session cache file
 
 The session cache file uses the TOML format. The default file name is `.pyodk_cache.toml`, and the default location is the user home directory. The file name and location can be customised by setting the environment variable `PYODK_CACHE_FILE` to some other file path, or by passing the path at init with `Client(config_path="my_cache.toml")`. This file should not be pre-created as it is used to store a session token after login.

--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -146,20 +146,20 @@ class EntityService(bases.Service):
 
     def update(
         self,
-        label: str,
-        data: dict,
         uuid: str,
-        force: bool | None = None,
-        base_version: int | None = None,
         entity_list_name: str | None = None,
         project_id: int | None = None,
+        label: str | None = None,
+        data: dict | None = None,
+        force: bool | None = None,
+        base_version: int | None = None,
     ) -> Entity:
         """
         Update an Entity.
 
+        :param uuid: The unique identifier for the Entity.
         :param label: Label of the Entity.
         :param data: Data to store for the Entity.
-        :param uuid: The unique identifier for the Entity.
         :param force: If True, update an Entity regardless of its current state. If
           `base_version` is not specified, then `force` must be True.
         :param base_version: The expected current version of the Entity on the server. If
@@ -181,10 +181,11 @@ class EntityService(bases.Service):
                 params["baseVersion"] = pv.validate_int(base_version, key="base_version")
             if len([i for i in (force, base_version) if i is not None]) != 1:
                 raise PyODKError("Must specify one of 'force' or 'base_version'.")  # noqa: TRY301
-            req_data = {
-                "label": pv.validate_str(label, key="label"),
-                "data": pv.validate_dict(data, key="data"),
-            }
+            req_data = {}
+            if label is not None:
+                req_data["label"] = pv.validate_str(label, key="label")
+            if data is not None:
+                req_data["data"] = pv.validate_dict(data, key="data")
         except PyODKError as err:
             log.error(err, exc_info=True)
             raise

--- a/tests/resources/entities_data.py
+++ b/tests/resources/entities_data.py
@@ -14,6 +14,7 @@ test_entities = [
             "version": 1,
             "baseVersion": None,
             "conflictingProperties": None,
+            "data": {"firstName": "John", "age": "88"},
         },
     },
     {
@@ -29,9 +30,10 @@ test_entities = [
             "createdAt": "2018-03-21T12:45:02.312Z",
             "creatorId": 1,
             "userAgent": "Enketo/3.0.4",
-            "version": 1,
-            "baseVersion": None,
+            "version": 2,
+            "baseVersion": 1,
             "conflictingProperties": None,
+            "data": {"firstName": "John", "age": "88"},
         },
     },
 ]


### PR DESCRIPTION
Closes #73

#### What has been done to verify that this works as intended?

New unit and integration tests.

#### Why is this the best possible solution? Were any other approaches considered?

Added function is as specified in #73. One minor assumption: an error is raised if both `force` and `base_version` are provided. It seemed like that might be dangerous as well, e.g. user specifies the wrong base_version but gets an update anyway.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

New convenience method.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
