### PR TITLE
Fix docs dep install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies.
         run: |
           python -m pip install --upgrade pip
-          pip install -e[docs] .
+          pip install -e .[docs]
           pip list
 
       # Build and publish.


### PR DESCRIPTION
Docs publishing doesn't work because dependency installation isn't expressed quite right.