### PR TITLE
90: make enketoId and name optional in the Form model

### DIFF
--- a/pyodk/_endpoints/forms.py
+++ b/pyodk/_endpoints/forms.py
@@ -20,12 +20,12 @@ log = logging.getLogger(__name__)
 class Form(bases.Model):
     projectId: int
     xmlFormId: str
-    name: str
     version: str
-    enketoId: str
     hash: str
     state: str  # open, closing, closed
     createdAt: datetime
+    name: str | None  # Null if Central couldn't parse the XForm title, or it was blank.
+    enketoId: str | None  # Null if Enketo not being used with Central.
     keyId: int | None
     updatedAt: datetime | None
     publishedAt: datetime | None

--- a/tests/resources/forms_data.py
+++ b/tests/resources/forms_data.py
@@ -25,7 +25,7 @@ test_forms = {
             "projectId": 8,
             "xmlFormId": "external_52k",
             "state": "open",
-            "enketoId": "Mscnfqdz7w6Nz21gkPYdNNbmOKP6hpT",
+            "enketoId": None,
             "enketoOnceId": "0510ccec266c8e0c88e939c2597341e523535b0e18460fca7c8b4585826a157d",
             "createdAt": "2021-10-28T19:11:37.064Z",
             "updatedAt": "2021-10-28T19:11:59.047Z",
@@ -36,7 +36,7 @@ test_forms = {
             "sha256": "1c5ffdf837c153672fbd7858753c6fa41a8e5813423932e53162016139f11ca1",
             "draftToken": None,
             "publishedAt": "2021-10-28T19:11:57.082Z",
-            "name": "External 52k",
+            "name": None,
         },
         {
             "projectId": 8,


### PR DESCRIPTION
Closes #90

#### What has been done to verify that this works as intended?

Updated test fixture data to include a form where these fields are null, and ran the test suite.

#### Why is this the best possible solution? Were any other approaches considered?

I think I had made `name` and `enketoId` required since every request I made during testing had those fields.

I read the current [Central code](https://github.com/getodk/central-backend/blob/0cd56948854ecc544a1b4af9efd88cf9ceee153d/lib/model/frames/form.js) that seems to return this data. Per Line 79: nullable `enketoId`, and Line 117: nullable `name`. From what I can tell, Line 50 is saying that both fields are always part of the returned object, whether null or not. According to the forum thread linked in #90, and the Central docs, it's possible to use Central without Enketo and in that case `enketoId` may be blank. I assumed everyone used them together but apparently not. About the `name`, Central parses that out of the XForm title. According to the XHTML spec, a `head/title` is required but I'm not certain if it has to be non-blank. Also, pyxform tries to make sure a title is set, at least "data". In any case the XForm may be invalid somehow i.e. no title or blank. Since the above Central is willing to return a nullable `name`, presumably that is tolerable.

I think the Central API docs on Apiary used to say which fields were required or optional, but now it's only visible in the [source yaml file](https://github.com/getodk/central-backend/blob/0cd56948854ecc544a1b4af9efd88cf9ceee153d/docs/api.yaml#L3385), not the [published page](https://docs.getodk.org/central-api-form-management/#creating-a-new-form).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Unblocks users of pyodk + Central but with no Enketo.

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
