### PR TITLE
add: form creation with attachments

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -139,6 +139,16 @@ class TestUsage(TestCase):
         form = self.client.forms.create(definition=wb)
         self.assertTrue(form.xmlFormId.startswith("uuid:"))
 
+    def test_form_create__new_definition_xlsx_and_attachments(self):
+        """Should create a new form with the new definition and attachment."""
+        form_def = forms_data.get_md__pull_data()
+        wb = md_table_to_bytes(mdstr=form_def)
+        form = self.client.forms.create(
+            definition=wb,
+            attachments=[(RESOURCES / "forms" / "fruits.csv").as_posix()],
+        )
+        self.assertTrue(form.xmlFormId.startswith("uuid:"))
+
     # Below tests assume project has forms by these names already published.
     def test_form_update__new_definition(self):
         """Should create a new version with the new definition."""
@@ -175,7 +185,7 @@ class TestUsage(TestCase):
             self.assertEqual(form.xmlFormId, "✅")
 
     def test_form_update__with_version_updater__non_ascii_specials(self):
-        """Should create a new version with new definition and attachment."""
+        """Should create a new version with new definition."""
         self.client.forms.update(
             form_id="'=+/*-451%/%",
             attachments=[],


### PR DESCRIPTION
Closes #79

#### What has been done to verify that this works as intended?

New tests, checked E2E result in Central

#### Why is this the best possible solution? Were any other approaches considered?

Follows a similar pattern to forms.update but without the version update, and a definition is required. The attachment upload and publish are separate calls because the form creation endpoint in Central accepts only a form definition.

The returned Form object doesn't include info about the attachments, because if an upload fails then an error will be raised (before the form is published), so a user could assume that no error means all attachments were uploaded.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

New convenience feature to avoid needing to create then update just to upload attachments.

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

The method docstring is updated with the new parameter.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
