### PR TITLE
update dependencies, add job to test older pydantic

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,6 +41,12 @@ jobs:
       matrix:
         python: ['3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
+        pydantic: ['pydantic==2.9.2']
+        # Test pydantic at lower boundary of requirement compatibility spec.
+        include:
+          - python: '3.12'
+            os: ubuntu-latest
+            pydantic: 'pydantic==2.6.4'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -58,6 +64,7 @@ jobs:
       - name: Install dependencies.
         run: |
           python -m pip install --upgrade pip
+          pip install ${{ matrix.pydantic }}
           pip install -e .[dev,docs]
           pip list
 

--- a/docs/examples/2022-10-pyodk-webinar.ipynb
+++ b/docs/examples/2022-10-pyodk-webinar.ipynb
@@ -371,10 +371,11 @@
     }
    ],
    "source": [
-    "json = client.submissions.get_table(form_id='participants')['value']\n",
-    "\n",
     "import pandas as pd\n",
-    "df = pd.json_normalize(json, sep='-')\n",
+    "\n",
+    "json = client.submissions.get_table(form_id=\"participants\")[\"value\"]\n",
+    "\n",
+    "df = pd.json_normalize(json, sep=\"-\")\n",
     "df.head(3)"
    ]
   },
@@ -416,7 +417,7 @@
     }
    ],
    "source": [
-    "df.pets.value_counts().plot(kind='pie')"
+    "df.pets.value_counts().plot(kind=\"pie\")"
    ]
   },
   {
@@ -445,8 +446,8 @@
     }
    ],
    "source": [
-    "df['height_code'] = df.height_units.astype('category').cat.codes\n",
-    "df['pets_code'] = df.pets.astype('category').cat.codes\n",
+    "df[\"height_code\"] = df.height_units.astype(\"category\").cat.codes\n",
+    "df[\"pets_code\"] = df.pets.astype(\"category\").cat.codes\n",
     "df.pets_code.corr(df.height_code)"
    ]
   },
@@ -529,7 +530,7 @@
     }
    ],
    "source": [
-    "df['__system-submitterName'].value_counts().plot(kind='bar', rot=45)"
+    "df[\"__system-submitterName\"].value_counts().plot(kind=\"bar\", rot=45)"
    ]
   },
   {
@@ -547,7 +548,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = df.drop(df.filter(regex = 'note_'), axis = 1)"
+    "df = df.drop(df.filter(regex=\"note_\"), axis=1)"
    ]
   },
   {

--- a/docs/examples/basic-analysis-pandas.ipynb
+++ b/docs/examples/basic-analysis-pandas.ipynb
@@ -36,8 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyodk.client import Client\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from pyodk.client import Client"
    ]
   },
   {
@@ -228,9 +228,9 @@
    ],
    "source": [
     "with Client() as client:\n",
-    "    submissions = client.submissions.get_table(form_id='fav_color')\n",
-    "    df = pd.json_normalize(data=submissions['value'], sep='/')\n",
-    "    \n",
+    "    submissions = client.submissions.get_table(form_id=\"fav_color\")\n",
+    "    df = pd.json_normalize(data=submissions[\"value\"], sep=\"/\")\n",
+    "\n",
     "df.head(3)"
    ]
   },
@@ -272,9 +272,11 @@
     }
    ],
    "source": [
-    "colors = {'g':'Green', 'o':'Orange', 'r':'Red', 'y':'Yellow'}\n",
-    "df['favorite_color_labels'] = df['favorite_color'].map(colors)\n",
-    "df['favorite_color_labels'].value_counts().plot(kind='bar', title='Count of favorite colors', xlabel=\"Color\", ylabel=\"Count\", rot=0)"
+    "colors = {\"g\": \"Green\", \"o\": \"Orange\", \"r\": \"Red\", \"y\": \"Yellow\"}\n",
+    "df[\"favorite_color_labels\"] = df[\"favorite_color\"].map(colors)\n",
+    "df[\"favorite_color_labels\"].value_counts().plot(\n",
+    "    kind=\"bar\", title=\"Count of favorite colors\", xlabel=\"Color\", ylabel=\"Count\", rot=0\n",
+    ")"
    ]
   },
   {
@@ -313,7 +315,9 @@
     }
    ],
    "source": [
-    "df['__system/reviewState'].value_counts().plot(kind='pie', title='Submission review state', ylabel='', rot=0)"
+    "df[\"__system/reviewState\"].value_counts().plot(\n",
+    "    kind=\"pie\", title=\"Submission review state\", ylabel=\"\", rot=0\n",
+    ")"
    ]
   },
   {
@@ -357,13 +361,17 @@
     "import geopandas\n",
     "from geopandas import GeoDataFrame\n",
     "\n",
-    "world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))\n",
-    "base = world.plot(color='lightgrey', figsize=(15, 10))\n",
+    "world = geopandas.read_file(geopandas.datasets.get_path(\"naturalearth_lowres\"))\n",
+    "base = world.plot(color=\"lightgrey\", figsize=(15, 10))\n",
     "base.set_axis_off()\n",
     "\n",
-    "locations = pd.DataFrame(df['location/coordinates'].dropna().to_list(), columns=['x', 'y', 'alt'])\n",
-    "geodf = GeoDataFrame(locations, geometry=geopandas.points_from_xy(locations['x'], locations['y']))\n",
-    "geodf.plot(ax=base, marker='o', color='blue', markersize=15)"
+    "locations = pd.DataFrame(\n",
+    "    df[\"location/coordinates\"].dropna().to_list(), columns=[\"x\", \"y\", \"alt\"]\n",
+    ")\n",
+    "geodf = GeoDataFrame(\n",
+    "    locations, geometry=geopandas.points_from_xy(locations[\"x\"], locations[\"y\"])\n",
+    ")\n",
+    "geodf.plot(ax=base, marker=\"o\", color=\"blue\", markersize=15)"
    ]
   },
   {

--- a/docs/examples/beyond-library-methods.ipynb
+++ b/docs/examples/beyond-library-methods.ipynb
@@ -168,7 +168,7 @@
     }
    ],
    "source": [
-    "response = client.get('/projects/7/forms/favorite_color/versions/2012060405.xlsx')\n",
+    "response = client.get(\"/projects/7/forms/favorite_color/versions/2012060405.xlsx\")\n",
     "response.content[:150]"
    ]
   },
@@ -188,7 +188,7 @@
    "outputs": [],
    "source": [
     "if response.status_code == 200:\n",
-    "    with open('2012060405.xlsx', 'wb') as f:\n",
+    "    with open(\"2012060405.xlsx\", \"wb\") as f:\n",
     "        f.write(response.content)"
    ]
   },
@@ -245,7 +245,7 @@
     }
    ],
    "source": [
-    "r = client.post('/projects/7/app-users', json={'displayName': 'Lab Tech'})\n",
+    "r = client.post(\"/projects/7/app-users\", json={\"displayName\": \"Lab Tech\"})\n",
     "r.json()"
    ]
   },

--- a/docs/examples/working-with-repeats.ipynb
+++ b/docs/examples/working-with-repeats.ipynb
@@ -31,11 +31,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyodk.client import Client\n",
     "import pandas as pd\n",
+    "from pyodk.client import Client\n",
     "\n",
     "client = Client().open()\n",
-    "submissions = client.submissions.get_table(form_id='simple_repeat', filter=\"__system/reviewState ne 'rejected'\")"
+    "submissions = client.submissions.get_table(\n",
+    "    form_id=\"simple_repeat\", filter=\"__system/reviewState ne 'rejected'\"\n",
+    ")"
    ]
   },
   {
@@ -195,7 +197,7 @@
     }
    ],
    "source": [
-    "subs_df = pd.json_normalize(data=submissions['value'], sep='/')\n",
+    "subs_df = pd.json_normalize(data=submissions[\"value\"], sep=\"/\")\n",
     "subs_df.head(3)"
    ]
   },
@@ -288,8 +290,12 @@
     }
    ],
    "source": [
-    "repeats = client.submissions.get_table(form_id='simple_repeat', table_name='Submissions.observation', filter=\"__system/reviewState ne 'rejected'\")\n",
-    "obs_df = pd.json_normalize(data=repeats['value'], sep='/')\n",
+    "repeats = client.submissions.get_table(\n",
+    "    form_id=\"simple_repeat\",\n",
+    "    table_name=\"Submissions.observation\",\n",
+    "    filter=\"__system/reviewState ne 'rejected'\",\n",
+    ")\n",
+    "obs_df = pd.json_normalize(data=repeats[\"value\"], sep=\"/\")\n",
     "obs_df.head(3)"
    ]
   },
@@ -511,7 +517,7 @@
     }
    ],
    "source": [
-    "subs_df.set_index('__id', inplace=True)\n",
+    "subs_df.set_index(\"__id\", inplace=True)\n",
     "joined_df = obs_df.join(subs_df, on=\"__Submissions-id\")\n",
     "joined_df.head(4)"
    ]
@@ -629,7 +635,7 @@
     }
    ],
    "source": [
-    "grouped = joined_df.groupby(['name', 'thing']).sum('count')[['count']]\n",
+    "grouped = joined_df.groupby([\"name\", \"thing\"]).sum(\"count\")[[\"count\"]]\n",
     "grouped"
    ]
   },
@@ -651,7 +657,7 @@
     }
    ],
    "source": [
-    "ax = grouped.unstack(level=0).plot(kind='bar')\n",
+    "ax = grouped.unstack(level=0).plot(kind=\"bar\")\n",
     "ax.set_xlabel(\"Sighting\")\n",
     "ax.set_ylabel(\"Total count\")\n",
     "ax.legend().set_title(\"Data collector\")"
@@ -842,12 +848,14 @@
     "\n",
     "client = Client().open()\n",
     "# The expand option includes all repeats in the json returned by get_table\n",
-    "submissions = client.submissions.get_table(form_id='simple_repeat', expand='*', filter=\"__system/reviewState ne 'rejected'\")\n",
+    "submissions = client.submissions.get_table(\n",
+    "    form_id=\"simple_repeat\", expand=\"*\", filter=\"__system/reviewState ne 'rejected'\"\n",
+    ")\n",
     "# Flatten all repeats for each submission returned\n",
-    "df = pd.DataFrame([flatten_json(x) for x in submissions['value']])\n",
+    "df = pd.DataFrame([flatten_json(x) for x in submissions[\"value\"]])\n",
     "\n",
     "# Drop system columns so we can see more of the repeats\n",
-    "df.drop(list(df.filter(regex = '__system')), axis = 1, inplace = True)\n",
+    "df.drop(list(df.filter(regex=\"__system\")), axis=1, inplace=True)\n",
     "df.head(3)"
    ]
   }

--- a/pyodk/_endpoints/auth.py
+++ b/pyodk/_endpoints/auth.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 class AuthService:
     def __init__(self, session: "Session", cache_path: str | None = None) -> None:
-        self.session: "Session" = session
+        self.session: Session = session
         self.cache_path: str = cache_path
 
     def verify_token(self, token: str) -> str:

--- a/pyodk/_utils/session.py
+++ b/pyodk/_utils/session.py
@@ -64,7 +64,7 @@ class Adapter(HTTPAdapter):
 
 class Auth(AuthBase):
     def __init__(self, session: "Session", username: str, password: str, cache_path: str):
-        self.session: "Session" = session
+        self.session: Session = session
         self.username: str = username
         self.password: str = password
         self.service: AuthService = AuthService(session=session, cache_path=cache_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,16 @@ description = "The official Python library for ODK 🐍"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "requests==2.32.0",  # HTTP with Central
+    "requests==2.32.3",  # HTTP with Central
     "toml==0.10.2",      # Configuration files
-    "pydantic==2.6.4",   # Data validation
+    "pydantic>=2.6.4,<2.9.3",   # Data validation. Ensure actions verify.yml matches range.
 ]
 
 [project.optional-dependencies]
 # Install with `pip install pyodk[dev]`.
 dev = [
-    "ruff==0.3.4",        # Format and lint
-    "openpyxl==3.1.2",    # Create test XLSX files
+    "ruff==0.7.1",        # Format and lint
+    "openpyxl==3.1.5",    # Create test XLSX files
     "xlwt==1.3.0",        # Create test XLS files
 ]
 docs = [


### PR DESCRIPTION
- pydantic dependency assumes latest version in the range.
  - added actions job tests with the lower bound as well.
  - probably most likely package to cause conflicts for users e.g. #94
  - requests not tested this way because often its releases are for security patches.
    - e.g. 2.32.0 and 2.32.1 were yanked for security reasons
- includes formatting changes via ruff update

#### What has been done to verify that this works as intended?

Ran tests locally and GitHub actions CI

#### Why is this the best possible solution? Were any other approaches considered?

As mentioned above

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Updates dependencies to latest versions

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
