### PR TITLE
Allow pyodk to be configured via environment variable, as well as config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ The `Client` is specific to a configuration and cache file. These approximately 
 - Setting environment variables `PYODK_CONFIG_FILE` and `PYODK_CACHE_FILE`
 - Init arguments: `Client(config_path="my_config.toml", cache_path="my_cache.toml")`.
 
+### Environment variables
+
+Alternatively, instead of a config file, it is possible to use environment variables for configuration.
+
+The available options are:
+
+```dotenv
+# If one is set, they must all be set
+PYODK_CENTRAL_URL=https://example.com
+PYODK_CENTRAL_USER=user@example.com
+PYODK_CENTRAL_PASS=yourpassword
+
+# Optional variable
+PYODK_DEFAULT_PROJECT_ID=1
+```
+
 ### Default project
 
 The `Client` is not specific to a project, but a default `project_id` can be set by:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,3 +92,79 @@ class TestConfig(TestCase):
         self.assertEqual(
             "Config value 'password' must not be empty.", err.exception.args[0]
         )
+
+    def test_read_envvars____ok__required_vars_present(self):
+        """Successfully reads environment variables as PyOdk config."""
+        cfg = {
+            "PYODK_CENTRAL_URL": "https://env.vars.config.com",
+            "PYODK_CENTRAL_USER": "user@env.vars.config.com",
+            "PYODK_CENTRAL_PASS": "DifferentPassword",
+        }
+
+        with patch.dict(os.environ, cfg, clear=True):
+            new_config = config.read_config()
+            self.assertEqual(new_config.central.base_url, cfg["PYODK_CENTRAL_URL"])
+            self.assertEqual(new_config.central.username, cfg["PYODK_CENTRAL_USER"])
+            self.assertEqual(new_config.central.password, cfg["PYODK_CENTRAL_PASS"])
+
+    def test_read_envvars__error_missing_required_env_var(self):
+        """Raise an error when no config is provided and required env vars are missing."""
+        cfg = {
+            "PYODK_CENTRAL_USER": "https://env.vars.config.com",
+            "PYODK_CENTRAL_PASS": "user@env.vars.config.com",
+            # Missing PYODK_CENTRAL_URL
+        }
+        with patch.dict(os.environ, cfg, clear=True):
+            with self.assertRaises(PyODKError) as err:
+                config.read_config()
+            self.assertIn("No valid configuration found", str(err.exception))
+
+    def test_read_envvars__ok__with_empty_default_project_id(self):
+        """All required env vars are set, but PYODK_DEFAULT_PROJECT_ID is empty string."""
+        cfg = {
+            "PYODK_CENTRAL_URL": "https://env.vars.config.com",
+            "PYODK_CENTRAL_USER": "user@env.vars.config.com",
+            "PYODK_CENTRAL_PASS": "DifferentPassword",
+            "PYODK_DEFAULT_PROJECT_ID": "",  # Empty string should be ignored
+        }
+        with patch.dict(os.environ, cfg, clear=True):
+            conf = config.read_config()
+            self.assertEqual(conf.central.base_url, cfg["PYODK_CENTRAL_URL"])
+            self.assertEqual(conf.central.username, cfg["PYODK_CENTRAL_USER"])
+            self.assertEqual(conf.central.password, cfg["PYODK_CENTRAL_PASS"])
+            self.assertEqual(conf.central.default_project_id, None)
+
+    def test_read_envvars__ok__with_valid_default_project_id(self):
+        """Return config and include PYODK_DEFAULT_PROJECT_ID when it is provided."""
+        cfg = {
+            "PYODK_CENTRAL_URL": "https://env.vars.config.com",
+            "PYODK_CENTRAL_USER": "user@env.vars.config.com",
+            "PYODK_CENTRAL_PASS": "DifferentPassword",
+            "PYODK_DEFAULT_PROJECT_ID": "123",
+        }
+        with patch.dict(os.environ, cfg, clear=True):
+            conf = config.read_config()
+            self.assertEqual(conf.central.base_url, cfg["PYODK_CENTRAL_URL"])
+            self.assertEqual(conf.central.username, cfg["PYODK_CENTRAL_USER"])
+            self.assertEqual(conf.central.password, cfg["PYODK_CENTRAL_PASS"])
+            self.assertEqual(
+                conf.central.default_project_id, cfg["PYODK_DEFAULT_PROJECT_ID"]
+            )
+
+    def test_read_config__ok__file_takes_precedence(self):
+        """If env vars are present, but a file is specified, it takes precedence."""
+        cfg = {
+            "PYODK_CENTRAL_URL": "https://env.vars.config.com",
+            "PYODK_CENTRAL_USER": "user@env.vars.config.com",
+            "PYODK_CENTRAL_PASS": "DifferentPassword",
+            "PYODK_DEFAULT_PROJECT_ID": "123",
+        }
+        with patch.dict(os.environ, cfg, clear=True):
+            conf = config.read_config(config_path=resources.CONFIG_FILE)
+            # Check the env var values aren't present in config
+            self.assertNotEqual(conf.central.base_url, cfg["PYODK_CENTRAL_URL"])
+            self.assertNotEqual(conf.central.username, cfg["PYODK_CENTRAL_USER"])
+            self.assertNotEqual(conf.central.password, cfg["PYODK_CENTRAL_PASS"])
+            self.assertNotEqual(
+                conf.central.default_project_id, cfg["PYODK_DEFAULT_PROJECT_ID"]
+            )


### PR DESCRIPTION
**This PR should not be merged, it is here to more visually show code changes**

- Added option to configure pyodk by 4 environment variables, matching the config TOML file options.
- The order of priority is:
  - User specified config file, if valid file.
  - Default config file, if valid file.
  - Environment variables.
  - Error if none of the above present.
- The environment variables are:
    ```dotenv
    # If one is set, they must all be set
    PYODK_CENTRAL_URL=https://example.com
    PYODK_CENTRAL_USER=user@example.com
    PYODK_CENTRAL_PASS=yourpassword
    
    # Optional variable
    PYODK_DEFAULT_PROJECT_ID=1
    ```