### PR TITLE
106: Support Python 3.10 - 3.13

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,7 +80,7 @@ jobs:
           flit --debug build --no-use-vcs
       - name: Upload sdist and wheel.
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pyodk--on-${{ matrix.os }}--py${{ matrix.python }}
           path: ${{ github.workspace }}/dist/pyodk*

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,12 +41,12 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
-        pydantic: ['pydantic==2.9.2']
+        pydantic: ['2.9.2']
         # Test pydantic at lower boundary of requirement compatibility spec.
         include:
           - python: '3.12'
             os: ubuntu-latest
-            pydantic: 'pydantic==2.6.4'
+            pydantic: '2.6.4'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies.
         run: |
           python -m pip install --upgrade pip
-          pip install ${{ matrix.pydantic }}
+          pip install pydantic==${{ matrix.pydantic }}
           pip install -e .[dev,docs]
           pip list
 
@@ -82,7 +82,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: pyodk--on-${{ matrix.os }}--py${{ matrix.python }}
+          name: pyodk--on-${{ matrix.os }}--py${{ matrix.python }}--pydantic${{ matrix.pydantic }}
           path: ${{ github.workspace }}/dist/pyodk*
 
       # Check docs.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,7 +39,7 @@ jobs:
       # Run all matrix jobs even if one of them fails.
       fail-fast: false
       matrix:
-        python: ['3.12']
+        python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
         pydantic: ['pydantic==2.9.2']
         # Test pydantic at lower boundary of requirement compatibility spec.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This library aims to make common data analysis and workflow automation tasks as 
 
 ## Install
 
-The currently supported Python version for `pyodk` is 3.12. If this is different from the version you use for other projects, consider using [`pyenv`](https://github.com/pyenv/pyenv) to manage multiple versions of Python.
+The currently supported Python versions for `pyodk` are 3.10 to 3.13 (the primary development version is 3.12). If this is different from the version you use for other projects, consider using [`pyenv`](https://github.com/pyenv/pyenv) to manage multiple versions of Python.
 
-The currently supported Central version is v2024.1.0. Newer or older Central versions will likely work too, but convenience (non-HTTP) methods assume this version. If you see a 404 error or another server error, please verify the version of your Central server.
+The currently supported Central version is v2024.3.1. Newer or older Central versions will likely work too, but convenience (non-HTTP) methods assume this version. If you see a 404 error or another server error, please verify the version of your Central server.
 
 ### From pip
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "The official Python library for ODK 🐍"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = [
     "requests==2.32.3",  # HTTP with Central
     "toml==0.10.2",      # Configuration files
@@ -44,7 +44,7 @@ exclude = ["docs", "tests"]
 
 [tool.ruff]
 line-length = 90
-target-version = "py312"
+target-version = "py310"
 fix = true
 show-fixes = true
 output-format = "full"

--- a/tests/resources/forms_data.py
+++ b/tests/resources/forms_data.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 test_forms = {
@@ -80,14 +80,14 @@ def get_xml__range_draft(
     form_id: str | None = "range_draft", version: str | None = None
 ) -> str:
     if version is None:
-        version = datetime.now(UTC).isoformat()
+        version = datetime.now(timezone.utc).isoformat()
     with open(Path(__file__).parent / "forms" / "range_draft.xml") as fd:
         return fd.read().format(form_id=form_id, version=version)
 
 
 def get_md__pull_data(version: str | None = None) -> str:
     if version is None:
-        version = datetime.now(UTC).isoformat()
+        version = datetime.now(timezone.utc).isoformat()
     return f"""
     | settings |
     |          | version   |

--- a/tests/utils/entity_lists.py
+++ b/tests/utils/entity_lists.py
@@ -25,10 +25,10 @@ def create_new_or_get_entity_list(
                 eln=entity_list_name,
             ),
         )
-    for prop in entity_props:
-        try:
+    try:
+        for prop in entity_props:
             client.entity_lists.add_property(name=prop, entity_list_name=entity_list_name)
-        except PyODKError as err:
-            if not err.is_central_error(code=409.3):
-                raise
+    except PyODKError as err:
+        if not err.is_central_error(code=409.3):
+            raise
     return EntityList(**entity_list.json())


### PR DESCRIPTION
Closes #106

#### What has been done to verify that this works as intended?

Updated CI jobs to test on all versions.

#### Why is this the best possible solution? Were any other approaches considered?

The ticket says up to 3.12, but 3.13 has been out for about 18 months and there as a [forum post](https://forum.getodk.org/t/50108) about it in Oct 2024. According to pypi, requests supports python 3.8-12, toml 3.3-9, pydantic 3.8-13.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should enable more use cases without affecting existing python 3.12 use. There were some minor code / formatting changes but these should not affect users.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

Updated Readme doc with the new versions. As noted there the primary dev version is still 3.12 for now, and I updated the quoted Central version since that's the version on staging and the E2E tests in `test_client.py` pass against it.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
