### PR TITLE
Docs CI fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,6 @@ jobs:
       # Publish docs.
       - name: Publish docs to gh-pages
         run: mkdocs gh-deploy --force
+        env:
+          # Silences platformdirs DeprecationWarning for jupyter v6 (not released yet).
+          JUPYTER_PLATFORM_DIRS: 1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,3 +88,6 @@ jobs:
       # Check docs.
       - name: Check docs
         run: mkdocs build --strict
+        env:
+          # Silences platformdirs DeprecationWarning for jupyter v6 (not released yet).
+          JUPYTER_PLATFORM_DIRS: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,10 @@ dev = [
     "xlwt==1.3.0",        # Create test XLS files
 ]
 docs = [
-    "mkdocs==1.5.3",
-    "mkdocstrings==0.24.1",
-    "griffe==0.37",
-    "mkdocs-autorefs==1.2.0",
-    "mkdocstrings-python==1.9.0",
-    "mkdocs-jupyter==0.24.6",
+    "mkdocs==1.6.1",
+    "mkdocstrings==0.28.3",
+    "mkdocstrings-python==1.16.3",
+    "mkdocs-jupyter==0.25.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ docs = [
     "mkdocs==1.5.3",
     "mkdocstrings==0.24.1",
     "griffe==0.37",
+    "mkdocs-autorefs==1.2.0",
     "mkdocstrings-python==1.9.0",
     "mkdocs-jupyter==0.24.6",
 ]


### PR DESCRIPTION
Fixes CI docs build job failure at `mkdocs build --strict` step, which blocks the automated tests job in GitHub actions file `verify.yml` ([example Actions run](https://github.com/getodk/pyodk/actions/runs/13757052515)). Probably would block publishing in `release.yml` as well.

#### What has been done to verify that this works as intended?

- CI docs build job passed
- local docs build passed
- checked each page in local docs build vs. current published version
- pages look the same and nothing obviously weird looking (desktop view size, Firefox v136).

#### Why is this the best possible solution? Were any other approaches considered?

Initially I just kicked the can down the road by adding a dependency for `mkdocs-autorefs`. But I thought I'd see if the most recent docs deps versions were compatible with Python 3.12 and each other, and it seems they are. If it had required changing configs (`mkdocs.yml`) or content changes (especially the notebooks) then I probably would have left it alone for now instead.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Fixes CI but otherwise docs unchanged.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

N/A

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
