### PR TITLE
102: submission attachment upload with submission.create

### DIFF
--- a/pyodk/_endpoints/submission_attachments.py
+++ b/pyodk/_endpoints/submission_attachments.py
@@ -1,0 +1,135 @@
+import logging
+import mimetypes
+from dataclasses import dataclass
+from os import PathLike
+
+from pyodk._endpoints.bases import Model, Service
+from pyodk._utils import validators as pv
+from pyodk._utils.session import Session
+from pyodk.errors import PyODKError
+
+log = logging.getLogger(__name__)
+
+
+class SubmissionAttachment(Model):
+    name: str
+    exists: bool
+
+
+@dataclass(frozen=True, slots=True)
+class URLs:
+    _submission: str = "projects/{project_id}/forms/{form_id}/submissions/{instance_id}"
+    list: str = f"{_submission}/attachments"
+    post: str = f"{_submission}/attachments/{{fname}}"
+
+
+class SubmissionAttachmentService(Service):
+    __slots__ = (
+        "urls",
+        "session",
+        "default_project_id",
+        "default_form_id",
+        "default_instance_id",
+    )
+
+    def __init__(
+        self,
+        session: Session,
+        default_project_id: int | None = None,
+        default_form_id: str | None = None,
+        default_instance_id: str | None = None,
+        urls: URLs = None,
+    ):
+        self.urls: URLs = urls if urls is not None else URLs()
+        self.session: Session = session
+        self.default_project_id: int | None = default_project_id
+        self.default_form_id: str | None = default_form_id
+        self.default_instance_id: str | None = default_instance_id
+
+    def list(
+        self,
+        form_id: str | None = None,
+        project_id: int | None = None,
+        instance_id: str | None = None,
+    ) -> list[SubmissionAttachment]:
+        """
+        Read all Submission Attachment details.
+
+        :param form_id: The xmlFormId of the Form being referenced.
+        :param project_id: The id of the project the Submissions belong to.
+        :param instance_id: The instanceId of the Submission being referenced.
+        """
+        try:
+            pid = pv.validate_project_id(project_id, self.default_project_id)
+            fid = pv.validate_form_id(form_id, self.default_form_id)
+            iid = pv.validate_instance_id(instance_id, self.default_instance_id)
+        except PyODKError as err:
+            log.error(err, exc_info=True)
+            raise
+
+        response = self.session.response_or_error(
+            method="GET",
+            url=self.session.urlformat(
+                self.urls.list, project_id=pid, form_id=fid, instance_id=iid
+            ),
+            logger=log,
+        )
+        data = response.json()
+        return [SubmissionAttachment(**r) for r in data]
+
+    def upload(
+        self,
+        file_path: PathLike | str,
+        file_name: str | None = None,
+        project_id: int | None = None,
+        form_id: str | None = None,
+        instance_id: str | None = None,
+    ) -> bool:
+        """
+        Upload a Submission Attachment.
+
+        :param file_path: The path to the file to upload.
+        :param file_name: A name for the file, otherwise the name in file_path is used.
+        :param project_id: The id of the project this form belongs to.
+        :param form_id: The xmlFormId of the Form being referenced.
+        :param instance_id: The instanceId of the Submission being referenced.
+        """
+        try:
+            pid = pv.validate_project_id(project_id, self.default_project_id)
+            fid = pv.validate_form_id(form_id, self.default_form_id)
+            iid = pv.validate_instance_id(instance_id, self.default_instance_id)
+            file_path = pv.validate_file_path(file_path)
+            if file_name is None:
+                file_name = pv.validate_str(file_path.name, key="file_name")
+            guess_type, guess_encoding = mimetypes.guess_type(file_name)
+            headers = {
+                "Transfer-Encoding": "chunked",
+                "Content-Type": guess_type or "application/octet-stream",
+            }
+            if guess_encoding:  # associated compression type, if any.
+                headers["Content-Encoding"] = guess_encoding
+        except PyODKError as err:
+            log.error(err, exc_info=True)
+            raise
+
+        def file_stream():
+            # Generator forces requests to read/send in chunks instead of all at once.
+            with open(file_path, "rb") as f:
+                while chunk := f.read(self.session.blocksize):
+                    yield chunk
+
+        response = self.session.response_or_error(
+            method="POST",
+            url=self.session.urlformat(
+                self.urls.post,
+                project_id=pid,
+                form_id=fid,
+                instance_id=iid,
+                fname=file_name,
+            ),
+            logger=log,
+            headers=headers,
+            data=file_stream(),
+        )
+        data = response.json()
+        return data["success"]

--- a/pyodk/_endpoints/submissions.py
+++ b/pyodk/_endpoints/submissions.py
@@ -239,9 +239,7 @@ class SubmissionService(Service):
         :param project_id: The id of the project this form belongs to.
         :param device_id: An optional deviceID associated with the submission.
         :param encoding: The encoding of the submission XML, default "utf-8".
-        :param attachments: The file paths of the attachment(s) to upload. For fine-tuned
-          control over how each file is uploaded, wrap the file_path and desired settings
-          in an instance of `SubmissionAttachmentSettings`.
+        :param attachments: The file paths of the attachment(s) to upload.
         """
         try:
             pid = pv.validate_project_id(project_id, self.default_project_id)

--- a/tests/endpoints/test_submissions.py
+++ b/tests/endpoints/test_submissions.py
@@ -1,11 +1,43 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import wraps
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from pyodk._endpoints.submission_attachments import SubmissionAttachmentService
 from pyodk._endpoints.submissions import Submission
 from pyodk._utils.session import Session
 from pyodk.client import Client
 
 from tests.resources import CONFIG_DATA, submissions_data
+
+
+@dataclass
+class MockContext:
+    sa_list: MagicMock
+    sa_upload: MagicMock
+
+
+def get_mock_context(func) -> Callable:
+    """
+    Inject a context object with mocks for testing related services.
+
+    To use, add a keyword argument "ctx" to the decorated function.
+    """
+
+    @wraps(func)
+    def patched(*args, **kwargs):
+        with (
+            patch.object(SubmissionAttachmentService, "list", return_value=[]) as sa_list,
+            patch.object(
+                SubmissionAttachmentService, "upload", return_value=True
+            ) as sa_upload,
+        ):
+            ctx = MockContext(sa_list=sa_list, sa_upload=sa_upload)
+            kwargs.update({"ctx": ctx})
+            return func(*args, **kwargs)
+
+    return patched
 
 
 @patch("pyodk._utils.session.Auth.login", MagicMock())
@@ -45,7 +77,8 @@ class TestSubmissions(TestCase):
                 )
                 self.assertIsInstance(observed, Submission)
 
-    def test_create__ok(self):
+    @get_mock_context
+    def test_create__ok(self, ctx: MockContext):
         """Should return a Submission object."""
         fixture = submissions_data.test_submissions
         with patch.object(Session, "request") as mock_session:
@@ -65,6 +98,27 @@ class TestSubmissions(TestCase):
                     xml=submissions_data.test_xml,
                 )
                 self.assertIsInstance(observed, Submission)
+
+    @get_mock_context
+    def test_create__with_attachments__ok(self, ctx: MockContext):
+        """Should return a Submission object, and call the attachments service."""
+        fixture = submissions_data.test_submissions
+        with patch.object(Session, "request") as mock_session:
+            mock_session.return_value.status_code = 200
+            mock_session.return_value.json.return_value = fixture["response_data"][1]
+            with Client() as client:
+                observed = client.submissions.create(
+                    project_id=fixture["project_id"],
+                    form_id=fixture["form_id"],
+                    xml=submissions_data.upload_file_xml.format(
+                        iid=fixture["response_data"][1]["instanceId"],
+                        file_name="a.jpg",
+                    ),
+                    attachments=["/some/path/a.jpg"],
+                )
+                self.assertIsInstance(observed, Submission)
+                self.assertEqual(1, ctx.sa_upload.call_count)
+                self.assertEqual(1, ctx.sa_list.call_count)
 
     def test__put__ok(self):
         """Should return a Submission object."""

--- a/tests/resources/forms_data.py
+++ b/tests/resources/forms_data.py
@@ -117,3 +117,12 @@ md__dingbat = """
 |        | calculate | fruit      |           | pulldata('fruits', 'name', 'name_key', 'mango') |
 |        | note      | note_fruit | The fruit ${fruit} pulled from csv |                      |
 """
+md__upload_file = """
+| settings |
+|          | form_title  | form_id     | version |
+|          | upload_file | upload_file | 1       |
+| survey |
+|        | type  | name | label |
+|        | text  | name | Name  |
+|        | file  | file | File  |
+"""

--- a/tests/resources/submissions_data.py
+++ b/tests/resources/submissions_data.py
@@ -45,6 +45,27 @@ test_xml = """
   <age>36</age>
 </data>
 """
+upload_file_xml = """
+<data id="upload_file" version="1">
+  <meta><instanceID>{iid}</instanceID></meta>
+  <name>file</name>
+  <file>{file_name}</file>
+</data>
+"""
+upload_file_submissions = {
+    "project_id": 1,
+    "form_id": "upload_file",
+    "response_data": [
+        {
+            "instanceId": "uuid:85cb9aff-005e-4edd-9739-dc9c1a829c45",
+            "submitterId": 10,
+            "deviceId": None,
+            "createdAt": "2025-03-14T06:21:29.581Z",
+            "updatedAt": None,
+            "reviewState": None,
+        },
+    ],
+}
 
 
 def get_xml__fruits(

--- a/tests/utils/entity_lists.py
+++ b/tests/utils/entity_lists.py
@@ -18,12 +18,14 @@ def create_new_or_get_entity_list(
     except PyODKError as err:
         if not err.is_central_error(code=409.3):
             raise
-        entity_list = client.session.get(
-            url=client.session.urlformat(
-                "projects/{pid}/datasets/{eln}",
-                pid=client.project_id,
-                eln=entity_list_name,
-            ),
+        entity_list = EntityList(
+            **client.session.get(
+                url=client.session.urlformat(
+                    "projects/{pid}/datasets/{eln}",
+                    pid=client.project_id,
+                    eln=entity_list_name,
+                ),
+            ).json()
         )
     try:
         for prop in entity_props:
@@ -31,4 +33,4 @@ def create_new_or_get_entity_list(
     except PyODKError as err:
         if not err.is_central_error(code=409.3):
             raise
-    return EntityList(**entity_list.json())
+    return entity_list


### PR DESCRIPTION
Closes #102

- accepts a list of paths and sends in chunks to account for large files
  - adds setting on session object for blocksize, although it is the same as default it allows customisation for advanced users
- fix: entity_list test fixture creation flow, noticed when running tests against a new Central instance (dev)

#### What has been done to verify that this works as intended?

Added unit and integration tests, plus some manual testing to check behaviour mentioned below.

#### Why is this the best possible solution? Were any other approaches considered?

In reference to #102 the code could now look like:

```python
#!/usr/bin/env python3

from pathlib import Path
from pyodk.client import Client

client = Client()
for folder in Path("/Users/me/Desktop/instances").iterdir():
    if folder.is_dir():
        client.submissions.create(
            project_id=1,
            form_id="my_form",
            xml=(folder / "instance.xml").read_text(),
            attachments=(f for f in folder.iterdir() if f.is_file() and f.name != "instance.xml")
        )
```

Also considered:

- send the files without chunking
  - pros: easiest
  - cons:
    - possible memory issues for sending large files
    - possible bug in Central where "Content-Type" not read for chunked transfers which means all files default to "application/octet-stream" even though pyodk is sending a mime type (guessed from file name). The content-type is saved as expected when the file isn't chunked. Not sure of any impact on Collect/Enketo/Webforms if the content-type is wrong e.g. are images not displayed? Asked about this in Slack.
- allowing more customisation e.g. by exposing upload params via a SubmissionAttachmentSettings object.
  - pros: allows fine tuning upload of each file: content-type, encoding, chunking
  - cons:
    - may cause awkward backwards compatibility scenarios in future if options or defaults need to change etc
    - may not cover all advanced use cases anyway, e.g. parallel uploads, or upload file names that are different to local names
    - more complicated code / tests to account for all behaviour paths e.g. optional params specified or not specified, chunking mode and non-chunking mode, etc.
- using the OpenRosa endpoint for submissions
  - pros: most similar to Collect/Enketo(?) client usage
  - cons:
    - would result in a submission that entirely works or doesn't; at least the current code will proceed until the first upload fails or everything works.
    - all other pyodk code uses the Central endpoints rather than OpenRosa
    - not sure how the content-type / chunking works for OpenRosa API usage (presumably at least content-type works)
- including a warning if the provided attachments are more or less than what Central expects
  - pros: could be helpful if a user forgot to include files (no error from Central) or tried to send unreferenced files (this would error 404 from Central)
  - cons: not sure if it's a realistic or common occurrence
- including a warning if multiple files have the same name (e.g. in different directory paths)
  - pros: could be helpful if a user doesn't realise that this happened and/or that it results in overwrites and the most recently submitted file will be saved
  - cons: not sure if it's a realistic or common occurrence
- not adding the blocksize code to session.py
  - pros: less code
  - cons:
    - less obvious what the blocksize is (took a bit of digging to find, ultimately it's defined by urllib3)
    - makes it easier to get the max transmit blocksize consistent with the local file buffer chunk size

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

New functionality requested in #102

#### Do we need any specific form for testing your changes? If so, please attach one.

Included in new tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

Added detailed docstring to SubmissionService. In particular the point about having to include a file reference in the submission XML, since that confused me initially and I didn't see that documented elsewhere.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
