### PR TITLE
103: avoid pydantic v3 DeprecationWarning when warnings are enabled

### DIFF
--- a/pyodk/_endpoints/bases.py
+++ b/pyodk/_endpoints/bases.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from pyodk._utils.session import Session
 
@@ -6,9 +6,7 @@ from pyodk._utils.session import Session
 class Model(BaseModel):
     """Base configuration for data model classes."""
 
-    class Config:
-        arbitrary_types_allowed = True
-        validate_assignment = True
+    model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
 
 
 class Manager:

--- a/pyodk/_endpoints/comments.py
+++ b/pyodk/_endpoints/comments.py
@@ -1,7 +1,8 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
@@ -9,21 +10,19 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class Comment(bases.Model):
+class Comment(Model):
     body: str
     actorId: int
     createdAt: datetime
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     list: str = "projects/{project_id}/forms/{form_id}/submissions/{instance_id}/comments"
     post: str = "projects/{project_id}/forms/{form_id}/submissions/{instance_id}/comments"
 
 
-class CommentService(bases.Service):
+class CommentService(Service):
     __slots__ = (
         "urls",
         "session",

--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -6,7 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 from pyodk.__version__ import __version__
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.entity_list_properties import EntityListPropertyService
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
@@ -43,7 +43,7 @@ class MergeActions:
         return (self.source_keys | self.target_keys) - self.reserved_keys
 
 
-class CurrentVersion(bases.Model):
+class CurrentVersion(Model):
     label: str
     current: bool
     createdAt: datetime
@@ -55,7 +55,7 @@ class CurrentVersion(bases.Model):
     conflictingProperties: list[str] | None = None
 
 
-class Entity(bases.Model):
+class Entity(Model):
     uuid: str
     creatorId: int
     createdAt: datetime
@@ -65,10 +65,8 @@ class Entity(bases.Model):
     deletedAt: datetime | None = None
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     _entity_name: str = "projects/{project_id}/datasets/{el_name}"
     _entities: str = f"{_entity_name}/entities"
     list: str = _entities
@@ -78,7 +76,7 @@ class URLs(bases.Model):
     get_table: str = f"{_entity_name}.svc/Entities"
 
 
-class EntityService(bases.Service):
+class EntityService(Service):
     """
     Entity-related functionality is accessed through `client.entities`. For example:
 

--- a/pyodk/_endpoints/entity_list_properties.py
+++ b/pyodk/_endpoints/entity_list_properties.py
@@ -1,7 +1,8 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
@@ -9,21 +10,19 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class EntityListProperty(bases.Model):
+class EntityListProperty(Model):
     name: str
     odataName: str
     publishedAt: datetime
     forms: list[str]
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     post: str = "projects/{project_id}/datasets/{entity_list_name}/properties"
 
 
-class EntityListPropertyService(bases.Service):
+class EntityListPropertyService(Service):
     __slots__ = (
         "urls",
         "session",

--- a/pyodk/_endpoints/entity_lists.py
+++ b/pyodk/_endpoints/entity_lists.py
@@ -1,8 +1,9 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.entity_list_properties import (
     EntityListProperty,
     EntityListPropertyService,
@@ -14,7 +15,7 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class EntityList(bases.Model):
+class EntityList(Model):
     name: str
     projectId: int
     createdAt: datetime
@@ -22,17 +23,15 @@ class EntityList(bases.Model):
     properties: list[EntityListProperty] | None = None
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     _entity_list = "projects/{project_id}/datasets"
     list: str = _entity_list
     post: str = _entity_list
     get: str = f"{_entity_list}/{{entity_list_name}}"
 
 
-class EntityListService(bases.Service):
+class EntityListService(Service):
     """
     Entity List-related functionality is accessed through `client.entity_lists`.
 

--- a/pyodk/_endpoints/form_assignments.py
+++ b/pyodk/_endpoints/form_assignments.py
@@ -1,6 +1,7 @@
 import logging
+from dataclasses import dataclass
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
@@ -8,15 +9,13 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     post: str = f"{_form}/assignments/{{role_id}}/{{user_id}}"
 
 
-class FormAssignmentService(bases.Service):
+class FormAssignmentService(Service):
     __slots__ = ("urls", "session", "default_project_id", "default_form_id")
 
     def __init__(

--- a/pyodk/_endpoints/form_draft_attachments.py
+++ b/pyodk/_endpoints/form_draft_attachments.py
@@ -1,7 +1,8 @@
 import logging
+from dataclasses import dataclass
 from os import PathLike
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
@@ -9,15 +10,13 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     post: str = f"{_form}/draft/attachments/{{fname}}"
 
 
-class FormDraftAttachmentService(bases.Service):
+class FormDraftAttachmentService(Service):
     __slots__ = ("urls", "session", "default_project_id", "default_form_id")
 
     def __init__(

--- a/pyodk/_endpoints/form_drafts.py
+++ b/pyodk/_endpoints/form_drafts.py
@@ -1,9 +1,10 @@
 import logging
+from dataclasses import dataclass
 from io import BytesIO
 from os import PathLike
 from zipfile import is_zipfile
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
@@ -81,16 +82,14 @@ def get_definition_data(
     return definition_data, content_type, file_path_stem
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     post: str = f"{_form}/draft"
     post_publish: str = f"{_form}/draft/publish"
 
 
-class FormDraftService(bases.Service):
+class FormDraftService(Service):
     __slots__ = ("urls", "session", "default_project_id", "default_form_id")
 
     def __init__(

--- a/pyodk/_endpoints/forms.py
+++ b/pyodk/_endpoints/forms.py
@@ -1,10 +1,11 @@
 import logging
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from datetime import datetime
 from os import PathLike
 from typing import Any
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.form_draft_attachments import FormDraftAttachmentService
 from pyodk._endpoints.form_drafts import FormDraftService
 from pyodk._utils import validators as pv
@@ -17,7 +18,7 @@ log = logging.getLogger(__name__)
 # TODO: actual response has undocumented fields: enketoOnceId, sha, sha256, draftToken
 
 
-class Form(bases.Model):
+class Form(Model):
     projectId: int
     xmlFormId: str
     version: str
@@ -31,15 +32,13 @@ class Form(bases.Model):
     publishedAt: datetime | None
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     forms: str = "projects/{project_id}/forms"
     get: str = f"{forms}/{{form_id}}"
 
 
-class FormService(bases.Service):
+class FormService(Service):
     """
     Form-related functionality is accessed through `client.forms`. For example:
 

--- a/pyodk/_endpoints/project_app_users.py
+++ b/pyodk/_endpoints/project_app_users.py
@@ -1,7 +1,8 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
@@ -9,7 +10,7 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class ProjectAppUser(bases.Model):
+class ProjectAppUser(Model):
     projectId: int
     id: int
     displayName: str
@@ -20,15 +21,13 @@ class ProjectAppUser(bases.Model):
     deletedAt: datetime | None
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     list: str = "projects/{project_id}/app-users"
     post: str = "projects/{project_id}/app-users"
 
 
-class ProjectAppUserService(bases.Service):
+class ProjectAppUserService(Service):
     __slots__ = (
         "urls",
         "session",

--- a/pyodk/_endpoints/projects.py
+++ b/pyodk/_endpoints/projects.py
@@ -1,9 +1,10 @@
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.form_assignments import FormAssignmentService
 from pyodk._endpoints.project_app_users import ProjectAppUser, ProjectAppUserService
 from pyodk._utils import validators as pv
@@ -13,7 +14,7 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class Project(bases.Model):
+class Project(Model):
     id: int
     name: str
     createdAt: datetime
@@ -27,17 +28,15 @@ class Project(bases.Model):
     deletedAt: datetime | None = None
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     list: str = "projects"
     get: str = "projects/{project_id}"
     get_data: str = "projects/{project_id}/forms/{form_id}.svc/{table_name}"
     post_app_users: str = "projects/{project_id}/app-users"
 
 
-class ProjectService(bases.Service):
+class ProjectService(Service):
     """
     Project-related functionality is accessed through `client.projects`. For example:
 

--- a/pyodk/_endpoints/submissions.py
+++ b/pyodk/_endpoints/submissions.py
@@ -1,9 +1,10 @@
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from pyodk._endpoints import bases
+from pyodk._endpoints.bases import Model, Service
 from pyodk._endpoints.comments import Comment, CommentService
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
@@ -12,7 +13,7 @@ from pyodk.errors import PyODKError
 log = logging.getLogger(__name__)
 
 
-class Submission(bases.Model):
+class Submission(Model):
     instanceId: str
     submitterId: int
     createdAt: datetime
@@ -24,10 +25,8 @@ class Submission(bases.Model):
     updatedAt: datetime | None = None
 
 
-class URLs(bases.Model):
-    class Config:
-        frozen = True
-
+@dataclass(frozen=True, slots=True)
+class URLs:
     _form: str = "projects/{project_id}/forms/{form_id}"
     list: str = f"{_form}/submissions"
     get: str = f"{_form}/submissions/{{instance_id}}"
@@ -37,7 +36,7 @@ class URLs(bases.Model):
     put: str = f"{_form}/submissions/{{instance_id}}"
 
 
-class SubmissionService(bases.Service):
+class SubmissionService(Service):
     """
     Submission-related functionality is accessed through `client.submissions`. For example:
 


### PR DESCRIPTION
Closes #103

- update bases.Model config to equivalent pydantic v3 style
- URLs classes are meant to be mostly immutable reference objects, so swap to smaller dataclass alternative rather than updating the pydantic usage
- shorten imports from bases module

#### What has been done to verify that this works as intended?

Ran unit and integration tests. Checked warning behaviour by launching python:

- prior to commit, default warnings, no warning: `python -c "from pyodk import Client"`
- prior to commit, warnings forced on, warning shown: `python -Wdefault -c "from pyodk import Client"`
- post commit, warnings forced on, no warning shown: `python -Wdefault -c "from pyodk import Client"`

The warning in question:
```
/home/u/repos/pyodk/venv/lib/python3.12/site-packages/pydantic/_internal/_config.py:291: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
  warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```

#### Why is this the best possible solution? Were any other approaches considered?

Not addressed all pydantic v3 migration guidance, since it's not released yet and the versioning policy suggests that there may not be other breaking changes, e.g. related to Models. However the pydantic v1 compatibility modules will be removed which will require larger changes to pyodk, since that's used for input validation.

The pattern of changes in this PR will need to be applied to `submission_attachments.py` in #110, either in a follow up PR or an update to this PR after the other one is merged. Also, static type checker (such as mypy) output was not considered, since pyodk currently doesn't use one (just ruff/pycharm warnings) and it's likely such a tool would require other changes (at least to incorporate it into dev workflow).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

N/A

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

N/A

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
