### PR TITLE
Fix form attachments upload bug when using pyodk to update .csv attachments on an ODK Central instance using S3 storage

### DIFF
--- a/pyodk/_endpoints/form_draft_attachments.py
+++ b/pyodk/_endpoints/form_draft_attachments.py
@@ -56,6 +56,11 @@ class FormDraftAttachmentService(Service):
             log.error(err, exc_info=True)
             raise
 
+        headers = {}
+        # Add Content-Type header only for CSV files
+        if str(file_path).lower().endswith(".csv"):
+            headers["Content-Type"] = "text/csv"
+
         with open(file_path, "rb") as fd:
             response = self.session.response_or_error(
                 method="POST",
@@ -64,6 +69,7 @@ class FormDraftAttachmentService(Service):
                 ),
                 logger=log,
                 data=fd,
+                headers=headers if headers else None,
             )
         data = response.json()
         return data["success"]

--- a/tests/endpoints/test_forms.py
+++ b/tests/endpoints/test_forms.py
@@ -149,6 +149,115 @@ class TestForms(TestCase):
                     project_id=fixture["project_id"],
                 )
 
+    @get_mock_context
+    def test_create__with_csv_attachment__ok(self, ctx: MockContext):
+        """Should handle CSV attachments correctly."""
+        fixture = forms_data.test_forms
+        with patch.object(Session, "request") as mock_session:
+            mock_session.return_value.status_code = 200
+            mock_session.return_value.json.return_value = fixture["response_data"][1]
+            with Client() as client, utils.get_temp_file(suffix=".xml") as fp:
+                fp.write_text(forms_data.get_xml__range_draft())
+                # Create a temporary CSV file
+                with utils.get_temp_file(suffix=".csv") as csv_file:
+                    csv_file.write_text("name,age\nJohn,25\nJane,30")
+                    observed = client.forms.create(
+                        definition=fp,
+                        project_id=fixture["project_id"],
+                        form_id=fixture["response_data"][1]["xmlFormId"],
+                        attachments=[str(csv_file)],
+                    )
+                    self.assertIsInstance(observed, Form)
+                    # Verify that upload was called for the CSV file
+                    ctx.fda_upload.assert_called_once_with(
+                        file_path=str(csv_file),
+                        form_id=fixture["response_data"][1]["xmlFormId"],
+                        project_id=fixture["project_id"]
+                    )
+
+    @get_mock_context  
+    def test_update__csv_attachment__ok(self, ctx: MockContext):
+        """Should handle CSV attachments correctly in updates."""
+        with utils.get_temp_file(suffix=".csv") as csv_file:
+            csv_file.write_text("name,age,city\nJohn,25,NYC\nJane,30,LA")
+            client = Client()
+            client.forms.update("foo", attachments=[str(csv_file)])
+            
+            # Verify the upload was called
+            ctx.fda_upload.assert_called_once_with(
+                file_path=str(csv_file), 
+                form_id="foo", 
+                project_id=None
+            )
+
+    # Test the FormDraftAttachmentService upload method directly
+    def test_form_draft_attachment_upload__csv_sets_headers(self):
+        """Should set Content-Type header for CSV files in FormDraftAttachmentService.upload."""
+        with patch.object(Session, "response_or_error") as mock_response:
+            # Mock successful response
+            mock_response.return_value.json.return_value = {"success": True}
+            
+            # Create service instance with mocked session
+            mock_session = MagicMock()
+            mock_session.urlformat.return_value = "http://test.url"
+            mock_session.response_or_error = mock_response
+            
+            service = FormDraftAttachmentService(
+                session=mock_session, 
+                default_project_id=1
+            )
+            
+            with utils.get_temp_file(suffix=".csv") as csv_file:
+                csv_file.write_text("name,age\nJohn,25")
+                
+                result = service.upload(
+                    file_path=csv_file,
+                    form_id="test_form", 
+                    project_id=1
+                )
+                
+                # Verify response_or_error was called with CSV headers
+                mock_response.assert_called_once()
+                call_kwargs = mock_response.call_args.kwargs
+                
+                self.assertIn("headers", call_kwargs)
+                self.assertEqual(call_kwargs["headers"]["Content-Type"], "text/csv")
+                self.assertTrue(result)
+
+    def test_form_draft_attachment_upload__non_csv_no_headers(self):
+        """Should not set Content-Type header for non-CSV files."""
+        with patch.object(Session, "response_or_error") as mock_response:
+            # Mock successful response  
+            mock_response.return_value.json.return_value = {"success": True}
+            
+            # Create service instance with mocked session
+            mock_session = MagicMock()
+            mock_session.urlformat.return_value = "http://test.url"
+            mock_session.response_or_error = mock_response
+            
+            service = FormDraftAttachmentService(
+                session=mock_session,
+                default_project_id=1
+            )
+            
+            with utils.get_temp_file(suffix=".jpg") as img_file:
+                img_file.write_bytes(b"fake image data")
+                
+                result = service.upload(
+                    file_path=img_file,
+                    form_id="test_form",
+                    project_id=1
+                )
+                
+                # Verify response_or_error was called without headers or with None
+                mock_response.assert_called_once()
+                call_kwargs = mock_response.call_args.kwargs
+                
+                if "headers" in call_kwargs:
+                    self.assertIsNone(call_kwargs["headers"])
+                
+                self.assertTrue(result)
+
     def test_update__def_or_attach_required(self):
         """Should raise an error if both 'definition' and 'attachments' are None."""
         with self.assertRaises(PyODKError) as err:


### PR DESCRIPTION
Issue:
When .csv files are uploaded as form attachments through pyodk to ODK Central servers using S3-compatible storage, the Content-Type header is not set correctly. This causes ODK Central to throw internal server errors when attempting to access these files later.

Solution:
- Added logic to detect CSV files (case-insensitive `.csv` extension)
- Set `Content-Type: text/csv` header specifically for CSV uploads
- Maintained original behavior for all other file types

#### What has been done to verify that this works as intended?
- Manually tested this behavior with an ODK Central server using S3 storage
- Added unit tests for CSV header handling. N.B.: I'm not familiar with writing unit tests, and so had claude do this part. I feel uncomfortable vouching for their comprehensiveness.

#### Why is this the best possible solution? Were any other approaches considered?
- This seemed like the minimal required fix, changing only headers for form attachments, and only for .csv files. I have not tested whether this issue occurs if pyodk is used to upload other kinds of form attachments to servers using S3 storage, though I imagine that is a rarer workflow.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- This should theoretically not affect the behavior end users experience.

#### Do we need any specific form for testing your changes? If so, please attach one.
- Unneeded.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
- Should not.

#### Before submitting this PR, please make sure you have:
- [x ] included test cases for core behavior and edge cases in `tests`
- [x ] run `python -m unittest` and verified all tests pass
- [x ] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
    - N.B. - I only committed the changes ruff made for the tests I added. Ruff also suggested changes in a number of files I had not touched. 
- [x ] verified that any code or assets from external sources are properly credited in comments
