### PR TITLE
115: form attachments update for Central v2025.1, set content-type

### DIFF
--- a/pyodk/_endpoints/form_draft_attachments.py
+++ b/pyodk/_endpoints/form_draft_attachments.py
@@ -49,7 +49,7 @@ class FormDraftAttachmentService(Service):
         file_name: str | None = None,
         form_id: str | None = None,
         project_id: int | None = None,
-    ) -> FormAttachment:
+    ) -> bool:
         """
         Upload a Form Draft Attachment.
 
@@ -94,4 +94,9 @@ class FormDraftAttachmentService(Service):
             data=file_stream(),
         )
         data = response.json()
-        return FormAttachment(**data)
+        try:
+            # Response format prior to Central v2025.1 is constant `{"success": True}`.
+            return data["success"]
+        except KeyError:
+            # Response introduced in Central v2025.1. Model details currently not used.
+            return FormAttachment(**data).exists

--- a/pyodk/_endpoints/form_draft_attachments.py
+++ b/pyodk/_endpoints/form_draft_attachments.py
@@ -1,13 +1,25 @@
 import logging
+import mimetypes
 from dataclasses import dataclass
+from datetime import datetime
 from os import PathLike
 
-from pyodk._endpoints.bases import Service
+from pyodk._endpoints.bases import Model, Service
 from pyodk._utils import validators as pv
 from pyodk._utils.session import Session
 from pyodk.errors import PyODKError
 
 log = logging.getLogger(__name__)
+
+
+class FormAttachment(Model):
+    name: str
+    type: str  # image | audio | video | file
+    hash: str
+    exists: bool  # Either blobExists or dataExists is True
+    blobExists: bool  # Server has the file
+    datasetExists: bool  # File is linked to a Dataset
+    updatedAt: datetime  # When the file was created or deleted
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,7 +49,7 @@ class FormDraftAttachmentService(Service):
         file_name: str | None = None,
         form_id: str | None = None,
         project_id: int | None = None,
-    ) -> bool:
+    ) -> FormAttachment:
         """
         Upload a Form Draft Attachment.
 
@@ -52,18 +64,34 @@ class FormDraftAttachmentService(Service):
             file_path = pv.validate_file_path(file_path)
             if file_name is None:
                 file_name = pv.validate_str(file_path.name, key="file_name")
+            guess_type, guess_encoding = mimetypes.guess_type(file_name)
+            headers = {
+                "Transfer-Encoding": "chunked",
+                "Content-Type": guess_type or "application/octet-stream",
+            }
+            if guess_encoding:  # associated compression type, if any.
+                headers["Content-Encoding"] = guess_encoding
         except PyODKError as err:
             log.error(err, exc_info=True)
             raise
 
-        with open(file_path, "rb") as fd:
-            response = self.session.response_or_error(
-                method="POST",
-                url=self.session.urlformat(
-                    self.urls.post, project_id=pid, form_id=fid, fname=file_name
-                ),
-                logger=log,
-                data=fd,
-            )
+        def file_stream():
+            # Generator forces requests to read/send in chunks instead of all at once.
+            with open(file_path, "rb") as f:
+                while chunk := f.read(self.session.blocksize):
+                    yield chunk
+
+        response = self.session.response_or_error(
+            method="POST",
+            url=self.session.urlformat(
+                self.urls.post,
+                project_id=pid,
+                form_id=fid,
+                fname=file_name,
+            ),
+            logger=log,
+            headers=headers,
+            data=file_stream(),
+        )
         data = response.json()
-        return data["success"]
+        return FormAttachment(**data)

--- a/pyodk/_endpoints/forms.py
+++ b/pyodk/_endpoints/forms.py
@@ -167,7 +167,7 @@ class FormService(Service):
         if attachments is not None:
             fda = FormDraftAttachmentService(session=self.session, **self._default_kw())
             for attach in attachments:
-                if not fda.upload(file_path=attach, **fp_ids):
+                if not fda.upload(file_path=attach, **fp_ids).exists:
                     raise PyODKError("Form create (attachment upload) failed.")
 
         # Publish the draft.
@@ -231,7 +231,7 @@ class FormService(Service):
         if attachments is not None:
             fda = FormDraftAttachmentService(session=self.session, **self._default_kw())
             for attach in attachments:
-                if not fda.upload(file_path=attach, **fp_ids):
+                if not fda.upload(file_path=attach, **fp_ids).exists:
                     raise PyODKError("Form update (attachment upload) failed.")
 
         new_version = None

--- a/pyodk/_endpoints/forms.py
+++ b/pyodk/_endpoints/forms.py
@@ -167,7 +167,7 @@ class FormService(Service):
         if attachments is not None:
             fda = FormDraftAttachmentService(session=self.session, **self._default_kw())
             for attach in attachments:
-                if not fda.upload(file_path=attach, **fp_ids).exists:
+                if not fda.upload(file_path=attach, **fp_ids):
                     raise PyODKError("Form create (attachment upload) failed.")
 
         # Publish the draft.
@@ -231,7 +231,7 @@ class FormService(Service):
         if attachments is not None:
             fda = FormDraftAttachmentService(session=self.session, **self._default_kw())
             for attach in attachments:
-                if not fda.upload(file_path=attach, **fp_ids).exists:
+                if not fda.upload(file_path=attach, **fp_ids):
                     raise PyODKError("Form update (attachment upload) failed.")
 
         new_version = None

--- a/tests/endpoints/test_forms.py
+++ b/tests/endpoints/test_forms.py
@@ -175,7 +175,7 @@ class TestForms(TestCase):
                     project_id=fixture["project_id"],
                     form_id=fixture["response_data"][1]["xmlFormId"],
                 )
-                self.assertIsInstance(observed, FormAttachment)
+                self.assertIsInstance(observed, bool)
                 self.assertEqual(
                     {"Content-Type": "text/csv", "Transfer-Encoding": "chunked"},
                     mock_session.call_args.kwargs["headers"],
@@ -185,7 +185,7 @@ class TestForms(TestCase):
                     project_id=fixture["project_id"],
                     form_id=fixture["response_data"][1]["xmlFormId"],
                 )
-                self.assertIsInstance(observed, FormAttachment)
+                self.assertIsInstance(observed, bool)
                 self.assertEqual(
                     {"Content-Type": "image/jpeg", "Transfer-Encoding": "chunked"},
                     mock_session.call_args.kwargs["headers"],

--- a/tests/resources/forms_data.py
+++ b/tests/resources/forms_data.py
@@ -74,6 +74,17 @@ test_forms = {
         },
     ],
 }
+test_form_attachments = [
+    {
+        "name": "fruits.csv",
+        "type": "file",
+        "hash": "b61381f802d5ca6bc054e49e32471500",
+        "exists": True,
+        "blobExists": True,
+        "datasetExists": False,
+        "updatedAt": "2025-05-10T20:51:22.100Z",
+    }
+]
 
 
 def get_xml__range_draft(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -122,13 +122,19 @@ class TestUsage(TestCase):
             form_id="pull_data",
             instance_id=next(s.instanceId for s in submissions),
         )
-        print([projects, forms, submissions, form_data, form_data_params, comments])
+        self.assertIsNotNone(projects)
+        self.assertIsNotNone(forms)
+        self.assertIsNotNone(submissions)
+        self.assertIsNotNone(form_data)
+        self.assertIsNotNone(form_data_params)
+        self.assertIsNotNone(comments)
 
     def test_direct_context(self):
         with Client() as client:
             projects = client.projects.list()
             forms = client.forms.list()
-        print(projects, forms)
+        self.assertIsNotNone(projects)
+        self.assertIsNotNone(forms)
 
     def test_form_create__new_definition_xml(self):
         """Should create a new form with the new definition."""


### PR DESCRIPTION
Closes #115

- the form attachment upload endpoint now returns a json object representing attributes of the file, rather than a generic status message `{"success": True}`
- set a content-type header for form attachments, in the same way as for submission attachments, since both seem to require it when Central uses S3 file storage
  - it seems webforms errors out if no content-type is set, but enketo is OK
- also in test_client.py change the print() calls to basic non-none assertions since staging now has quite a lot of data which means those print calls are very noisy.

#### What has been done to verify that this works as intended?

Added unit test to check the content-type change, ran integration tests to check generally. Opened forms created before the change (enketo OK, webforms errored) and after the change (enketo OK, webforms different probably unrelated error - details in #115).

#### Why is this the best possible solution? Were any other approaches considered?

This follows the attachment handling for submission attachments, which seems appropriate since it appears Central treats these attachment types in a similar way (in regards to S3 storage etc).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The API change should allow pyodk to upload forms with attachments with Central 2025.1 (or later). The content-type change should allow forms with attachments uploaded via pyodk to work with webforms.

I'm not aware of workarounds or fixes for file attachments (submissions or forms) that have inaccurate content-types saved for them (sending the same file again doesn't seem to overwrite).

#### Do we need any specific form for testing your changes? If so, please attach one.

The tests include the required files / data etc.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

The form attachment upload method is not directly exposed by the pyodk API so it would not require a docs update.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
