### PR TITLE
112: Add a method for requesting a form definition

### DIFF
--- a/tests/endpoints/test_forms.py
+++ b/tests/endpoints/test_forms.py
@@ -115,6 +115,23 @@ class TestForms(TestCase):
                 )
                 self.assertIsInstance(observed, Form)
 
+    def test_get_xml__ok(self):
+        """Should return a str or bytes depending on the encoding parameter."""
+        fixture = forms_data.get_xml__range_draft().encode("utf-8")
+        with patch.object(Session, "request") as mock_session:
+            mock_session.return_value.status_code = 200
+            mock_session.return_value.content = fixture
+            with Client() as client:
+                # Specify project
+                observed = client.forms.get_xml(project_id=1, form_id="range_draft")
+                self.assertIsInstance(observed, str)
+                # Use default
+                observed = client.forms.get_xml(form_id="range_draft")
+                self.assertIsInstance(observed, str)
+                # Get bytes instead of string
+                observed = client.forms.get_xml(form_id="range_draft", encoding=None)
+                self.assertIsInstance(observed, bytes)
+
     @get_mock_context
     def test_create__ok(self, ctx: MockContext):
         """Should return a FormType object."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -136,6 +136,12 @@ class TestUsage(TestCase):
         self.assertIsNotNone(projects)
         self.assertIsNotNone(forms)
 
+    def test_form_get_xml__returns_xform(self):
+        """Should return the XForm XML document."""
+        xml = self.client.forms.get_xml(form_id="pull_data")
+        self.assertIsInstance(xml, str)
+        self.assertIn("<h:title>pull_data</h:title>", xml)
+
     def test_form_create__new_definition_xml(self):
         """Should create a new form with the new definition."""
         form_id = self.client.session.get_xform_uuid()


### PR DESCRIPTION
Closes #112

#### What has been done to verify that this works as intended?

Added unit test for the str/bytes code path, and client test to check against Central that the endpoint returns something that looks like XForms XML.

#### Why is this the best possible solution? Were any other approaches considered?

Follows the same code pattern as forms.get, except for returning a document so pydantic isn't used. An option was included to get the response bytes as-is since this can go to XML parsing libraries like lxml rather than bytes -> str -> parse. For the str/bytes control I considered requiring "encoding='bytes'" but "None" seemed a bit more intuitive in that bytes is not decoded. It could also be true/false flag but then it wouldn't be easy to specify a different encoding and there are some other endpoints that expose encoding options e.g. submissions.create.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Adds a new user-requested endpoint.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A existing test fixtures were used.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No the details are in the docstring.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
