### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
-        pydantic: ['2.9.2']
+        pydantic: ['2.11.7']
         # Test pydantic at lower boundary of requirement compatibility spec.
         include:
           - python: '3.12'

--- a/pyodk/_endpoints/comments.py
+++ b/pyodk/_endpoints/comments.py
@@ -24,11 +24,11 @@ class URLs:
 
 class CommentService(Service):
     __slots__ = (
-        "urls",
-        "session",
-        "default_project_id",
         "default_form_id",
         "default_instance_id",
+        "default_project_id",
+        "session",
+        "urls",
     )
 
     def __init__(

--- a/pyodk/_endpoints/entities.py
+++ b/pyodk/_endpoints/entities.py
@@ -92,7 +92,7 @@ class EntityService(Service):
     Entities are like instances.
     """
 
-    __slots__ = ("urls", "session", "default_project_id", "default_entity_list_name")
+    __slots__ = ("default_entity_list_name", "default_project_id", "session", "urls")
 
     def __init__(
         self,

--- a/pyodk/_endpoints/entity_list_properties.py
+++ b/pyodk/_endpoints/entity_list_properties.py
@@ -24,10 +24,10 @@ class URLs:
 
 class EntityListPropertyService(Service):
     __slots__ = (
-        "urls",
-        "session",
-        "default_project_id",
         "default_entity_list_name",
+        "default_project_id",
+        "session",
+        "urls",
     )
 
     def __init__(

--- a/pyodk/_endpoints/entity_lists.py
+++ b/pyodk/_endpoints/entity_lists.py
@@ -49,12 +49,12 @@ class EntityListService(Service):
     """
 
     __slots__ = (
-        "urls",
-        "session",
-        "_default_project_id",
         "_default_entity_list_name",
+        "_default_project_id",
         "_property_service",
         "add_property",
+        "session",
+        "urls",
     )
 
     def __init__(

--- a/pyodk/_endpoints/form_assignments.py
+++ b/pyodk/_endpoints/form_assignments.py
@@ -16,7 +16,7 @@ class URLs:
 
 
 class FormAssignmentService(Service):
-    __slots__ = ("urls", "session", "default_project_id", "default_form_id")
+    __slots__ = ("default_form_id", "default_project_id", "session", "urls")
 
     def __init__(
         self,

--- a/pyodk/_endpoints/form_draft_attachments.py
+++ b/pyodk/_endpoints/form_draft_attachments.py
@@ -29,7 +29,7 @@ class URLs:
 
 
 class FormDraftAttachmentService(Service):
-    __slots__ = ("urls", "session", "default_project_id", "default_form_id")
+    __slots__ = ("default_form_id", "default_project_id", "session", "urls")
 
     def __init__(
         self,

--- a/pyodk/_endpoints/form_drafts.py
+++ b/pyodk/_endpoints/form_drafts.py
@@ -90,7 +90,7 @@ class URLs:
 
 
 class FormDraftService(Service):
-    __slots__ = ("urls", "session", "default_project_id", "default_form_id")
+    __slots__ = ("default_form_id", "default_project_id", "session", "urls")
 
     def __init__(
         self,

--- a/pyodk/_endpoints/forms.py
+++ b/pyodk/_endpoints/forms.py
@@ -50,7 +50,7 @@ class FormService(Service):
     ```
     """
 
-    __slots__ = ("urls", "session", "default_project_id", "default_form_id")
+    __slots__ = ("default_form_id", "default_project_id", "session", "urls")
 
     def __init__(
         self,

--- a/pyodk/_endpoints/project_app_users.py
+++ b/pyodk/_endpoints/project_app_users.py
@@ -29,9 +29,9 @@ class URLs:
 
 class ProjectAppUserService(Service):
     __slots__ = (
-        "urls",
-        "session",
         "default_project_id",
+        "session",
+        "urls",
     )
 
     def __init__(

--- a/pyodk/_endpoints/projects.py
+++ b/pyodk/_endpoints/projects.py
@@ -48,7 +48,7 @@ class ProjectService(Service):
     ```
     """
 
-    __slots__ = ("urls", "session", "default_project_id")
+    __slots__ = ("default_project_id", "session", "urls")
 
     def __init__(
         self,

--- a/pyodk/_endpoints/submission_attachments.py
+++ b/pyodk/_endpoints/submission_attachments.py
@@ -25,11 +25,11 @@ class URLs:
 
 class SubmissionAttachmentService(Service):
     __slots__ = (
-        "urls",
-        "session",
-        "default_project_id",
         "default_form_id",
         "default_instance_id",
+        "default_project_id",
+        "session",
+        "urls",
     )
 
     def __init__(

--- a/pyodk/_endpoints/submissions.py
+++ b/pyodk/_endpoints/submissions.py
@@ -54,7 +54,7 @@ class SubmissionService(Service):
     ```
     """
 
-    __slots__ = ("urls", "session", "default_project_id", "default_form_id")
+    __slots__ = ("default_form_id", "default_project_id", "session", "urls")
 
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,15 @@ description = "The official Python library for ODK 🐍"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "requests==2.32.3",  # HTTP with Central
+    "requests>=2.32.4,<2.33",  # HTTP with Central.
     "toml==0.10.2",      # Configuration files
-    "pydantic>=2.6.4,<2.9.3",   # Data validation. Ensure actions verify.yml matches range.
+    "pydantic>=2.6.4,<=2.11.7",   # Data validation. Ensure actions verify.yml matches range.
 ]
 
 [project.optional-dependencies]
 # Install with `pip install pyodk[dev]`.
 dev = [
-    "ruff==0.7.1",        # Format and lint
+    "ruff==0.12.4",        # Format and lint
     "openpyxl==3.1.5",    # Create test XLSX files
     "xlwt==1.3.0",        # Create test XLS files
 ]
@@ -84,7 +84,6 @@ ignore = [
     "PLW2901",  # redefined-loop-name (usually not a bug)
     "RUF001",  # ambiguous-unicode-character-string (false positives on unicode tests)
     "S310",  # suspicious-url-open-usage (prone to false positives, ruff 0.1.11)
-    "S320",  # suspicious-xmle-tree-usage (according to defusedxml author lxml is safe)
     "S603",  # subprocess-without-shell-equals-true (prone to false positives, ruff 0.1.11)
     "TRY003",  # raise-vanilla-args (reasonable lint but would require large refactor)
 ]

--- a/tests/endpoints/test_forms.py
+++ b/tests/endpoints/test_forms.py
@@ -22,7 +22,7 @@ from pyodk._utils.session import Session
 from pyodk.client import Client
 from pyodk.errors import PyODKError
 
-from tests.resources import CONFIG_DATA, forms_data
+from tests.resources import CONFIG_DATA, RESOURCES, forms_data
 from tests.utils import utils
 from tests.utils.md_table import md_table_to_bytes, md_table_to_bytes_xls
 
@@ -163,7 +163,6 @@ class TestForms(TestCase):
         """Should return a FormAttachment object and set the Content-Type header."""
         fixture = forms_data.test_forms
         fixture_attachments = forms_data.test_form_attachments
-        from tests.resources import RESOURCES
 
         with patch.object(Session, "request") as mock_session:
             mock_session.return_value.status_code = 200


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

Ran tests + linter.

#### Why is this the best possible solution? Were any other approaches considered?

Last update was >6 months ago. Requests dependency spec was changed from `==` to `>=` since this package seems to get security patches [pretty frequently lately](https://requests.readthedocs.io/en/latest/community/updates/##release-history), so it seems like having pyodk block using a newer requests version is worse than the possibility of a functional incompatibility - in which case the user could specifically install an earlier requests version. The pydantic changes seem to be mainly performance, stability, etc.

Linting changes:
  - RUF023 (unsorted-dunder-slots) new rule (affected many files)
  - PLC0415 imports at top of file (affected test_forms.py)
  - S320 previously ignored rule no longer exists so it is deleted

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should not be any functional changes.

#### Do we need any specific form for testing your changes? If so, please attach one.

N/A

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

N/A

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
