### PR TITLE
Support authentication without a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ password = "my_password"
 default_project_id = 123
 ```
 
+If you prefer not to manage credentials via a file, provide the connection details
+directly when constructing the client:
+
+```python
+client = Client(
+    base_url="https://www.example.com",
+    username="my_user",
+    password="my_password",
+)
+```
+
+All three parameters must be supplied together. When they are provided the configuration
+file is not read, so this pattern works even when no TOML file exists. Omit the trio to
+fall back to the configuration file (optionally pointed to with `config_path`).
+
 ### Custom configuration file paths
 
 The `Client` is specific to a configuration and cache file. These approximately correspond to the session which the `Client` represents; it also encourages segregating credentials. These paths can be set by:


### PR DESCRIPTION
Closes #123 

<!-- 
Thank you for contributing to pyodk!

Before sending this PR, please read
https://github.com/getodk/pyodk/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

I have added the test class `TestClientDirectCredentials` which runs a simple integration test to verify the new authentication implementation succeeds. There is also a test which verifies the logic for when errors are expected to be raised.

Following the [testing instructions](https://github.com/getodk/pyodk?tab=readme-ov-file#testing), those tests passed. For the same reason as why the other test class in `tests/test_client.py` are skipped by default (quoted below), I've also skipped this test class by default.

> For interactive testing, debugging, or sanity checking workflows, end-to-end tests are stored in tests/test_client.py. These tests are not run by default because they require access to a live Central server. 

#### Why is this the best possible solution? Were any other approaches considered?

We also tested out a workaround on our end which was wrapping the `Client` in a context manager such that temporary files would be generated to dump credentials during use and then removed upon exit. This felt cumbersome in practice, and we have some concerns about this approach related to race conditions and security risks (see issue). 

We don't see any significant downsides to allowing direct passing of `base_url`, `username`, and `password` into the instantiation of `Client`. One consideration is that multiple ways of authenticating could feel less straightforward for users of the library. This is hopefully mitigitated by the defensive implentation that a config file is used XOR credentials files are directly passed in.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Intentional change:
- Users can now initialize a `Client` directly with `base_url`, `username`, and `password` instead of providing a TOML config file.

Unchanged behavior:
- File-based configuration continues to work exactly as before.
- Default behavior (`Client()` using `.pyodk_config.toml` from the home directory) remains intact.

Regression risk:
- Minimal. The new parameters are optional and only affect initialization when explicitly provided.

#### Do we need any specific form for testing your changes? If so, please attach one.

No specific form is needed; any Central instance with accessible credentials is sufficient to verify authentication. The tests can be run by removing the `@skip` decorator on the class.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

I updated the README.md to show the new direct initialization option. Are there additional docs to be updated?

Issue link: #123 

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
