### PR TITLE
123: allow managing auth data in memory only

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ password = "my_password"
 default_project_id = 123
 ```
 
+Users with configuration in environment variables, for example, can [pass them in as a Config object](https://getodk.github.io/pyodk/client/)
+
+
 ### Custom configuration file paths
 
 The `Client` is specific to a configuration and cache file. These approximately correspond to the session which the `Client` represents; it also encourages segregating credentials. These paths can be set by:

--- a/pyodk/_endpoints/auth.py
+++ b/pyodk/_endpoints/auth.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pyodk._utils import config
@@ -11,9 +12,9 @@ log = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, session: "Session", cache_path: str | None = None) -> None:
+    def __init__(self, session: "Session", cache_path: str | Path | None = None) -> None:
         self.session: Session = session
-        self.cache_path: str = cache_path
+        self.cache_path: str | Path | None = cache_path
 
     def verify_token(self, token: str) -> str:
         """
@@ -77,12 +78,16 @@ class AuthService:
         """
         Get a verified session token with the provided credential.
 
-        Tries to verify token in cache_file, or requests a new session.
+        Tries to verify token in cache_file, or requests a new session. If the cache_path
+        is not set, this will request a new session token for each call.
 
         :param username: The username of the Web User to auth with.
         :param password: The Web User's password.
         :return: The session token or None if anything has gone wrong
         """
+        if self.cache_path is None:
+            return self.get_new_token(username=username, password=password)
+
         try:
             token = config.read_cache_token(cache_path=self.cache_path)
             return self.verify_token(token=token)

--- a/pyodk/_utils/config.py
+++ b/pyodk/_utils/config.py
@@ -47,7 +47,7 @@ def objectify_config(config_data: dict) -> Config:
     return config
 
 
-def get_path(path: str, env_key: str) -> Path:
+def get_path(path: str | Path, env_key: str) -> Path:
     """
     Get a path from the path argument, the environment key, or the default.
     """
@@ -59,11 +59,11 @@ def get_path(path: str, env_key: str) -> Path:
     return defaults[env_key]
 
 
-def get_config_path(config_path: str | None = None) -> Path:
+def get_config_path(config_path: str | Path | None = None) -> Path:
     return get_path(path=config_path, env_key="PYODK_CONFIG_FILE")
 
 
-def get_cache_path(cache_path: str | None = None) -> Path:
+def get_cache_path(cache_path: str | Path | None = None) -> Path:
     return get_path(path=cache_path, env_key="PYODK_CACHE_FILE")
 
 
@@ -80,7 +80,7 @@ def read_toml(path: Path) -> dict:
         raise pyodk_err from err
 
 
-def read_config(config_path: str | None = None) -> Config:
+def read_config(config_path: str | Path | None = None) -> Config:
     """
     Read the config file.
     """
@@ -89,7 +89,7 @@ def read_config(config_path: str | None = None) -> Config:
     return objectify_config(config_data=file_data)
 
 
-def read_cache_token(cache_path: str | None = None) -> str:
+def read_cache_token(cache_path: str | Path | None = None) -> str:
     """
     Read the "token" key from the cache file.
     """
@@ -102,7 +102,7 @@ def read_cache_token(cache_path: str | None = None) -> str:
     return file_data["token"]
 
 
-def write_cache(key: str, value: str, cache_path: str | None = None) -> None:
+def write_cache(key: str, value: str, cache_path: str | Path | None = None) -> None:
     """
     Append or overwrite the given key/value pair to the cache file.
     """
@@ -116,7 +116,7 @@ def write_cache(key: str, value: str, cache_path: str | None = None) -> None:
         toml.dump(file_data, outfile)
 
 
-def delete_cache(cache_path: str | None = None) -> None:
+def delete_cache(cache_path: str | Path | None = None) -> None:
     """
     Delete the cache file, if it exists.
     """

--- a/pyodk/_utils/config.py
+++ b/pyodk/_utils/config.py
@@ -35,6 +35,13 @@ class CentralConfig:
 
 @dataclass
 class Config:
+    """
+    Configuration data for pyodk.
+
+    This is intended for users who already have credentials in memory and should not be
+    used to write credentials directly in a script.
+    """
+
     central: CentralConfig
 
 
@@ -84,7 +91,7 @@ def read_config(config_path: str | Path | None = None) -> Config:
     """
     Read the config file.
     """
-    file_path = get_path(path=config_path, env_key="PYODK_CONFIG_FILE")
+    file_path = get_config_path(config_path=config_path)
     file_data = read_toml(path=file_path)
     return objectify_config(config_data=file_data)
 

--- a/pyodk/_utils/session.py
+++ b/pyodk/_utils/session.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from pathlib import Path
 from string import Formatter
 from typing import Any
 from urllib.parse import quote, urljoin
@@ -71,7 +72,9 @@ class Adapter(HTTPAdapter):
 
 
 class Auth(AuthBase):
-    def __init__(self, session: "Session", username: str, password: str, cache_path: str):
+    def __init__(
+        self, session: "Session", username: str, password: str, cache_path: str | Path
+    ):
         self.session: Session = session
         self.username: str = username
         self.password: str = password
@@ -106,7 +109,7 @@ class Session(RequestsSession):
         api_version: str,
         username: str,
         password: str,
-        cache_path: str,
+        cache_path: str | Path | None = None,
         chunk_size: int = 16384,
     ) -> None:
         """
@@ -114,7 +117,8 @@ class Session(RequestsSession):
         :param api_version: The Central API version (first part of the URL path).
         :param username: The Central user name to log in with.
         :param password: The Central user's password to log in with.
-        :param cache_path: Where to read/write pyodk_cache.toml.
+        :param cache_path: Where to read/write pyodk_cache.toml. If None, the auth
+          session is stored only in memory in the "Authorization" session header.
         :param chunk_size: In bytes. For transferring large files (e.g. >1MB), it may be
           noticeably faster to use larger chunks than the default 16384 bytes (16KB).
         """

--- a/pyodk/client.py
+++ b/pyodk/client.py
@@ -25,6 +25,7 @@ class Client:
         "default_project_id" in pyodk_config.toml, or can be specified per call.
     :param session: A prepared pyodk.session.Session class instance, or an instance
         of a customised subclass.
+    :param config: A Config object containing details from pyodk_config.toml.
     :param api_version: The ODK Central API version, which is used in the URL path
         e.g. 'v1' in 'https://www.example.com/v1/projects'.
     """
@@ -100,7 +101,11 @@ class Client:
         return self
 
     def close(self, *args):
-        """Close the session."""
+        """
+        Close the session.
+
+        This only cleans up the Session, it does not invoke logout from Central.
+        """
         self.session.__exit__(*args)
 
     def __enter__(self) -> "Client":

--- a/pyodk/client.py
+++ b/pyodk/client.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from pathlib import Path
 
 from pyodk._endpoints.comments import CommentService
 from pyodk._endpoints.entities import EntityService
@@ -6,7 +7,7 @@ from pyodk._endpoints.entity_lists import EntityListService
 from pyodk._endpoints.forms import FormService
 from pyodk._endpoints.projects import ProjectService
 from pyodk._endpoints.submissions import SubmissionService
-from pyodk._utils import config
+from pyodk._utils import config as cfg
 from pyodk._utils.session import Session
 
 
@@ -30,23 +31,28 @@ class Client:
 
     def __init__(
         self,
-        config_path: str | None = None,
-        cache_path: str | None = None,
+        config_path: str | Path | None = None,
+        cache_path: str | Path | None = None,
         project_id: int | None = None,
         session: Session | None = None,
         api_version: str | None = "v1",
+        config: cfg.Config | None = None,
     ) -> None:
-        self.config: config.Config = config.read_config(config_path=config_path)
-        self._project_id: int | None = project_id
+        if config is None:
+            config = cfg.read_config(config_path=config_path)
+
         if session is None:
             session = Session(
-                base_url=self.config.central.base_url,
+                base_url=config.central.base_url,
                 api_version=api_version,
-                username=self.config.central.username,
-                password=self.config.central.password,
-                cache_path=cache_path,
+                username=config.central.username,
+                password=config.central.password,
+                cache_path=cfg.get_cache_path(cache_path=cache_path),
             )
+
+        self.config: cfg.Config = config
         self.session: Session = session
+        self._project_id: int | None = project_id
 
         # Delegate http verbs for ease of use.
         self.get: Callable = self.session.get


### PR DESCRIPTION
Closes #123

#### What has been done to verify that this works as intended?

Added tests in test_client with patches to check for API stability and skippable E2E tests that were run against staging.

#### Why is this the best possible solution? Were any other approaches considered?

The absence of auth parameters on the `Client` was a design choice to discourage putting credentials directly into scripts (e.g. in a notebook file like in the `docs/examples` directories) and instead encourage using a home/private directory since one of the motivating use cases for pyodk is the analyst and/or new coder.

However there have been requests from some more advanced library users that want to manage the auth data in memory and/or avoid writing files. Since pyodk writes the auth token to a cache file, a solution needs to account for that as well. So this PR implements a new pattern for passing in a Config object, which can optionally not cache the session to a file and thereby not touch any files at all. As noted in `test_client.py` it seems like Central caches sessions as well anyway.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be backwards compatible - I think the only clash would be if someone was importing `config` from `pyodk.client`, which is now aliased to `cfg` to avoid a name clash with the new `config` parameter. If that is a problem then the fix is just to replace `config` with `cfg` in the user's code import statement.

#### Do we need any specific form for testing your changes? If so, please attach one.

Some of the tests require a Central instance but these are skipped for CI.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

As mentioned above the new functionality is intended for advanced use cases so maybe it's better to not document it in the `readme`? It is at least demonstrated in the tests.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyodk tests` and `ruff check pyodk tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments
